### PR TITLE
add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
     author_email="chen08013@gmail.com",
     download_url="https://github.com/materialsvirtuallab/m3gnet",
     license="BSD",
-    install_requires=["numpy", "scikit-learn", "pymatgen>=2019.10.4", "monty"],
     extras_require={
         "model_saving": ["h5py"],
         "tensorflow": ["tensorflow>=2.7"],


### PR DESCRIPTION
Add pyproject.toml file, which is the recommended way to specify minimal
build system requirements (see PEP 518).
Before this, pip installing m3gnet directly from github would fail due
to missing numpy dependency.

Note: PEP 621 describes how to specify all project-related information
in the pyproject.toml as well (rather than in the `setup.py`).
However, I'm not sure this works when your package has Cython
extensions - so this commit just adds a minimal pyproject.toml as
recommended in the Cython documentation.