### PR TITLE
fix: re-add runtime dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ ci:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
 
@@ -43,6 +43,6 @@ repos:
           - --ignore-init-module-imports
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.930
+    rev: v0.960
     hooks:
       - id: mypy

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,15 @@ extension = [
 setup(
     name="m3gnet",
     version=version,
+    install_requires=[
+        "pymatgen>=2019.10.4",
+        "pandas",
+        "tensorflow",
+        "numpy",
+        "monty",
+        "sympy",
+        "ase",
+    ],
     description="Materials Graph with Three-body Interactions",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -66,7 +75,7 @@ setup(
         "networks",
         "neural",
         "force field",
-        "interatomic potential"
+        "interatomic potential",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Runtime dependencies in setup.py were accidentally deleted when adding
the `pyproject.toml` with the build time dependencies.