### PR TITLE
Fix passing pressure to ASE MD class when using NPT.

### DIFF
--- a/m3gnet/models/_dynamics.py
+++ b/m3gnet/models/_dynamics.py
@@ -293,7 +293,7 @@ class MolecularDynamics:
                 self.atoms,
                 timestep * units.fs,
                 temperature_K=temperature,
-                pressure=pressure,
+                pressure_au=pressure,
                 taut=taut,
                 taup=taup,
                 compressibility_au=compressibility_au,


### PR DESCRIPTION
M3gnet NPT asks for pressure in eV/A^3, but passes it to ASE using the depracated "pressure" variable, which expects bars. Fixed to pass the pressure to the "pressure_au" variable, which expects eV/A^3.
ASE documentation here: https://wiki.fysik.dtu.dk/ase/_modules/ase/md/nptberendsen.html#NPTBerendsen