### PR TITLE
Fix model download

### DIFF
--- a/m3gnet/models/_m3gnet.py
+++ b/m3gnet/models/_m3gnet.py
@@ -70,11 +70,10 @@ def _download_model_to_dir(model_name: str = "MP-2021.2.8-EFS", dirname: str = "
     if model_name not in MODEL_FILES:
         raise ValueError(f"{model_name} not supported. Currently we only have {MODEL_FILES.keys()}")
     full_dirname = os.path.join(CWD, dirname)
-    for name, files in MODEL_FILES[model_name].items():
-        if not os.path.isdir(full_dirname):
-            os.mkdir(full_dirname)
-        for f in files:
-            _download_file(GITHUB_RAW_LINK.format(model_name=name, filename=f), os.path.join(full_dirname, name))
+    if not os.path.isdir(full_dirname):
+        os.mkdir(full_dirname)
+    for filename in MODEL_FILES[model_name]:
+        _download_file(GITHUB_RAW_LINK.format(model_name=model_name, filename=filename), os.path.join(full_dirname, filename))
     logger.info(f"Model {model_name} downloaded to {full_dirname}")
 
 


### PR DESCRIPTION
**Problem:**
It seems the model download in 0.0.3 version is not working because of type error. 

**Details**

the `_download_model_to_dir` function is revised to fix the type error.