### PR TITLE
Added a more flexible NPT-MD scheme to MolecularDynamics class

### DIFF
--- a/m3gnet/models/_dynamics.py
+++ b/m3gnet/models/_dynamics.py
@@ -333,6 +333,7 @@ class MolecularDynamics:
             This is a less flexible scheme that fixes the shape of the
             cell - three angles are fixed and the ratios between the three
             lattice constants.
+            
             '''
             
             self.dyn = NPTBerendsen(

--- a/m3gnet/models/_dynamics.py
+++ b/m3gnet/models/_dynamics.py
@@ -302,16 +302,16 @@ class MolecularDynamics:
                 loginterval=loginterval,
                 append_trajectory=append_trajectory,
             )
-        
+
         elif ensemble.lower() == "npt":
             '''
-            
+
             NPT ensemble default to Inhomogeneous_NPTBerendsen thermo/barostat
             This is a more flexible scheme that fixes three angles of the unit
             cell but allows three lattice parameter to change independently.
-            
+
             '''
-            
+
             self.dyn = Inhomogeneous_NPTBerendsen(
                 self.atoms,
                 timestep * units.fs,
@@ -326,17 +326,17 @@ class MolecularDynamics:
                 # append_trajectory=append_trajectory,
                 # this option is not supported in ASE at this point (I have sent merge request there)
             )
-        
+
         elif ensemble.lower() == "npt_berendsen":
             '''
-            
+
             This is a similar scheme to the Inhomogeneous_NPTBerendsen.
             This is a less flexible scheme that fixes the shape of the
             cell - three angles are fixed and the ratios between the three
             lattice constants.
-            
+
             '''
-            
+
             self.dyn = NPTBerendsen(
                 self.atoms,
                 timestep * units.fs,
@@ -350,7 +350,7 @@ class MolecularDynamics:
                 loginterval=loginterval,
                 append_trajectory=append_trajectory,
             )
-            
+
         else:
             raise ValueError("Ensemble not supported")
 

--- a/m3gnet/models/_dynamics.py
+++ b/m3gnet/models/_dynamics.py
@@ -13,7 +13,7 @@ from ase import Atoms, units
 from ase.calculators.calculator import Calculator, all_changes
 from ase.constraints import ExpCellFilter
 from ase.io import Trajectory
-from ase.md.nptberendsen import NPTBerendsen
+from ase.md.nptberendsen import NPTBerendsen, Inhomogeneous_NPTBerendsen
 from ase.md.nvtberendsen import NVTBerendsen
 from ase.optimize.bfgs import BFGS
 from ase.optimize.bfgslinesearch import BFGSLineSearch
@@ -302,8 +302,39 @@ class MolecularDynamics:
                 loginterval=loginterval,
                 append_trajectory=append_trajectory,
             )
-
+        
         elif ensemble.lower() == "npt":
+            '''
+            
+            NPT ensemble default to Inhomogeneous_NPTBerendsen thermo/barostat
+            This is a more flexible scheme that fixes three angles of the unit
+            cell but allows three lattice parameter to change independently.
+            
+            '''
+            
+            self.dyn = Inhomogeneous_NPTBerendsen(
+                self.atoms,
+                timestep * units.fs,
+                temperature_K=temperature,
+                pressure_au=pressure,
+                taut=taut,
+                taup=taup,
+                compressibility_au=compressibility_au,
+                trajectory=trajectory,
+                logfile=logfile,
+                loginterval=loginterval,
+                # append_trajectory=append_trajectory, # this option is not supported in ASE at this point (I have sent merge request there)
+            )
+        
+        elif ensemble.lower() == "npt_berendsen":
+            '''
+            
+            This is a similar scheme to the Inhomogeneous_NPTBerendsen.
+            This is a less flexible scheme that fixes the shape of the
+            cell - three angles are fixed and the ratios between the three
+            lattice constants.
+            '''
+            
             self.dyn = NPTBerendsen(
                 self.atoms,
                 timestep * units.fs,
@@ -317,6 +348,7 @@ class MolecularDynamics:
                 loginterval=loginterval,
                 append_trajectory=append_trajectory,
             )
+            
         else:
             raise ValueError("Ensemble not supported")
 

--- a/m3gnet/models/_dynamics.py
+++ b/m3gnet/models/_dynamics.py
@@ -323,7 +323,8 @@ class MolecularDynamics:
                 trajectory=trajectory,
                 logfile=logfile,
                 loginterval=loginterval,
-                # append_trajectory=append_trajectory, # this option is not supported in ASE at this point (I have sent merge request there)
+                # append_trajectory=append_trajectory,
+                # this option is not supported in ASE at this point (I have sent merge request there)
             )
         
         elif ensemble.lower() == "npt_berendsen":


### PR DESCRIPTION
Added `Inhomogeneous_NPTBerendsen` scheme as the default scheme for NPT-MD (`ensemble = npt`) while preserving the old one as `ensemble = npt_berendsen`.