### PR TITLE
ASE MD classes expect timesteps in ASE time units.

### DIFF
--- a/m3gnet/models/_dynamics.py
+++ b/m3gnet/models/_dynamics.py
@@ -267,7 +267,7 @@ class MolecularDynamics:
             ensemble (str): choose from 'nvt' or 'npt'. NPT is not tested,
                 use with extra caution
             temperature (float): temperature for MD simulation, in K
-            timestep (float): time step in ASE units. Default value equals 1 fs 
+            timestep (float): time step in ASE units. Default value equals 1 fs
                 in ASE units.
             pressure (float): pressure in eV/A^3
             taut (float): time constant for Berendsen temperature coupling

--- a/m3gnet/models/_dynamics.py
+++ b/m3gnet/models/_dynamics.py
@@ -248,7 +248,7 @@ class MolecularDynamics:
         potential: Union[Potential, str] = "MP-2021.2.8-EFS",
         ensemble: str = "nvt",
         temperature: int = 300,
-        timestep: float = 1.0,
+        timestep: float = 0.098,
         pressure: float = 1.01325 * units.bar,
         taut: Optional[float] = None,
         taup: Optional[float] = None,
@@ -267,7 +267,8 @@ class MolecularDynamics:
             ensemble (str): choose from 'nvt' or 'npt'. NPT is not tested,
                 use with extra caution
             temperature (float): temperature for MD simulation, in K
-            timestep (float): time step in fs
+            timestep (float): time step in ASE units. Default value equals 1 fs 
+                in ASE units.
             pressure (float): pressure in eV/A^3
             taut (float): time constant for Berendsen temperature coupling
             taup (float): time constant for pressure coupling
@@ -294,7 +295,7 @@ class MolecularDynamics:
         if ensemble.lower() == "nvt":
             self.dyn = NVTBerendsen(
                 self.atoms,
-                timestep * units.fs,
+                timestep,
                 temperature_K=temperature,
                 taut=taut,
                 trajectory=trajectory,
@@ -314,7 +315,7 @@ class MolecularDynamics:
 
             self.dyn = Inhomogeneous_NPTBerendsen(
                 self.atoms,
-                timestep * units.fs,
+                timestep,
                 temperature_K=temperature,
                 pressure_au=pressure,
                 taut=taut,
@@ -339,7 +340,7 @@ class MolecularDynamics:
 
             self.dyn = NPTBerendsen(
                 self.atoms,
-                timestep * units.fs,
+                timestep,
                 temperature_K=temperature,
                 pressure_au=pressure,
                 taut=taut,


### PR DESCRIPTION
M3gnet passes the timestep to the ASE MD classes in units of fs, but ASE expects the timestep in ASE units, which are Angstroms*sqrt(u/eV), where u is the atomic mass unit. This causes issues in the MD and in subsequent analysis of the trajectories.

This pull request removes the unit conversion so that the correct units are passed to ASE, and changes the default timestep to equal 1 fs in ASE's units.

ASE units documentation: https://wiki.fysik.dtu.dk/ase/ase/units.html
ASE MD documentation: https://wiki.fysik.dtu.dk/ase/ase/md.html#constant-nvt-simulations-the-canonical-ensemble