### PR TITLE
Training with include_states and small batch size throws error

### DIFF
--- a/m3gnet/trainers/tests/test_trainer.py
+++ b/m3gnet/trainers/tests/test_trainer.py
@@ -27,6 +27,19 @@ class TestTrainer(unittest.TestCase):
             cls.energies.append(j["energy"])
             cls.bandgaps.append(j["band_gap"])
 
+    def test_train_with_state_and_batches(self):
+        """
+        This error only occurs when include_states=True and the batch size
+        is less than the number of data points you are training on (which
+        is typically the case)
+        """
+        m3gnet = M3GNet(n_blocks=1, units=5, is_intensive=True, include_states=True)
+        trainer = Trainer(model=m3gnet, optimizer=tf.keras.optimizers.Adam(1e-2))
+
+        # 50 > 32
+        trainer.train(self.structures[:50], self.bandgaps[:50], batch_size=32, epochs=2, train_metrics=["mae"])
+        self.assertTrue(m3gnet.predict_structures(self.structures[:2]).numpy().shape == (2, 1))
+
     def test_train_bandgap(self):
         m3gnet = M3GNet(n_blocks=1, units=5, is_intensive=True)
         trainer = Trainer(model=m3gnet, optimizer=tf.keras.optimizers.Adam(1e-2))


### PR DESCRIPTION
I found a strange issue when trying to train M3GNet models where I wanted to include states. 

I've added a commit below with a unit test that fails. 

In this test, the only changes I have made compared to test_band_gap is setting `include_states = True` and `batch_size = 32`. There's some sort of mismatch in expected dimensions between layers and it throws an error. I can include a full error traceback if it'd be helpful

