### PR TITLE
Update _potential.py - hard-code patience?

### DIFF
--- a/m3gnet/trainers/_potential.py
+++ b/m3gnet/trainers/_potential.py
@@ -177,7 +177,7 @@ class PotentialTrainer:
             )
 
         if early_stop_patience:
-            callbacks.append(tf.keras.callbacks.EarlyStopping(monitor="val_MAE", patience=200))
+            callbacks.append(tf.keras.callbacks.EarlyStopping(monitor="val_MAE", patience=early_stop_patience))
 
         callback_list = tf.keras.callbacks.CallbackList(callbacks)
         callback_list.on_train_begin()


### PR DESCRIPTION
It seems that the patience=200 is hard-coded here? Making patience=early_stop_patience will also be helpful for continued training (monitor training progress across different runs).