### PR TITLE
Expand `examples/Relaxation of LiFePO4.ipynb`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,9 @@ repos:
       - id: nbqa-isort
       - id: nbqa-pyupgrade
         args: [--py38-plus]
+
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.0
+    hooks:
+      - id: nbstripout
+        args: [--drop-empty-cells, --keep-output]

--- a/examples/Cubic Crystal Test.ipynb
+++ b/examples/Cubic Crystal Test.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "5f2426c3",
    "metadata": {},
    "outputs": [],
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "ddfff8e3",
    "metadata": {},
    "outputs": [],
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "8476d506",
    "metadata": {},
    "outputs": [
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "2541aebf",
    "metadata": {},
    "outputs": [
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "8cdd6407",
    "metadata": {},
    "outputs": [],
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "b71312dc",
    "metadata": {},
    "outputs": [
@@ -1733,7 +1733,7 @@
        "<pandas.io.formats.style.Styler at 0x17c640160>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1744,7 +1744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "423e7893",
    "metadata": {},
    "outputs": [
@@ -1754,7 +1754,7 @@
        "<AxesSubplot:>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1774,14 +1774,6 @@
    "source": [
     "data[\"% error vs MP\"].replace([np.inf, -np.inf], np.nan).dropna().hist(bins=20)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f56b07e4",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/Relaxation of LiFePO4.ipynb
+++ b/examples/Relaxation of LiFePO4.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "5818a2b9",
    "metadata": {},
    "outputs": [],
@@ -28,19 +28,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5e008446",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/shyue/repos/pymatgen/pymatgen/analysis/phase_diagram.py:24: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
-      "  from tqdm.autonotebook import tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import warnings\n",
     "\n",
@@ -56,19 +47,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "0cc2e942",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/shyue/repos/pymatgen/pymatgen/ext/matproj.py:1758: UserWarning: You are using a new API key. This unofficial MPRester support for the new API is intended purely to facilitate simple convenience queries in the interim. There are no plans to build this into a full-featured API client. It is highly recommended that you install the mp-api package for full API functionality.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mpr = MPRester()\n",
     "lfp = mpr.get_structure_by_material_id(\"mp-19017\")  # This is LiFePO4.\n",
@@ -83,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "f8897c0e",
    "metadata": {},
    "outputs": [
@@ -91,15 +73,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-07-28 13:54:26.805333: W tensorflow/core/platform/profile_utils/cpu_utils.cc:128] Failed to get CPU frequency: 0 Hz\n"
+      "2022-08-16 15:10:14.833037: W tensorflow/core/platform/profile_utils/cpu_utils.cc:128] Failed to get CPU frequency: 0 Hz\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 22.9 s, sys: 44.7 s, total: 1min 7s\n",
-      "Wall time: 12.6 s\n"
+      "CPU times: user 13.1 s, sys: 2.22 s, total: 15.3 s\n",
+      "Wall time: 9.48 s\n"
      ]
     }
    ],
@@ -107,7 +89,7 @@
     "relaxer = Relaxer()\n",
     "relax_results: dict\n",
     "%time relax_results = relaxer.relax(lfp_strained)\n",
-    "relaxed = relax_results[\"final_structure\"]"
+    "relaxed_struct = relax_results[\"final_structure\"]"
    ]
   },
   {
@@ -119,8 +101,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "d1b355f7",
+   "metadata": {},
+   "source": [
+    "The relaxation using the M3GNet universal IAP has brought the lattice parameters much closer to the original DFT ones and the coordinates are also within $10^{-3}$ of the original fractional coordinates."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "2abb1e07",
    "metadata": {},
    "outputs": [
@@ -129,74 +119,147 @@
      "output_type": "stream",
      "text": [
       "Original lattice parameters are [4.746, 10.444, 6.09]\n",
-      "Strained lattice parameters are [4.813, 10.658, 6.157]\n",
-      "Relaxed lattice parameters are [4.751, 10.451, 6.091]\n"
+      "Strained lattice parameters are [4.655, 10.116, 6.169]\n",
+      "Relaxed lattice parameters are [4.749, 10.447, 6.105]\n"
      ]
     }
    ],
    "source": [
     "print(f\"Original lattice parameters are {[round(x, 3) for x in lfp.lattice.abc]}\")\n",
     "print(f\"Strained lattice parameters are {[round(x, 3) for x in lfp_strained.lattice.abc]}\")\n",
-    "print(f\"Relaxed lattice parameters are {[round(x, 3) for x in relaxed.lattice.abc]}\")"
+    "print(f\"Relaxed lattice parameters are {[round(x, 3) for x in relaxed_struct.lattice.abc]}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "7b2ddfd6",
+   "execution_count": null,
+   "id": "1320a18b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[9.95585866e-01, 5.09294457e-04, 9.84189370e-01],\n",
+       "       [5.20894009e-01, 5.01713435e-01, 9.97474321e-01],\n",
+       "       [5.04853356e-01, 4.91625924e-01, 5.07732446e-01],\n",
+       "       [1.96716573e-02, 9.98423822e-01, 4.93991898e-01],\n",
+       "       [4.66972193e-01, 2.26221410e-01, 7.56598929e-01],\n",
+       "       [1.75367824e-02, 7.14677040e-01, 7.64243428e-01],\n",
+       "       [9.74532693e-01, 2.74308700e-01, 2.60366885e-01],\n",
+       "       [5.05152825e-01, 7.85728905e-01, 2.50998223e-01],\n",
+       "       [4.11383909e-01, 8.64375884e-02, 2.42736461e-01],\n",
+       "       [9.22660218e-01, 4.05067751e-01, 7.34201221e-01],\n",
+       "       [6.64774830e-02, 5.88037118e-01, 2.49265519e-01],\n",
+       "       [5.62188874e-01, 9.05333524e-01, 7.43938118e-01],\n",
+       "       [7.51256294e-01, 1.04193044e-01, 2.42070362e-01],\n",
+       "       [2.47872494e-01, 4.03677933e-01, 7.65556546e-01],\n",
+       "       [7.64247175e-01, 6.05980547e-01, 2.46644955e-01],\n",
+       "       [2.37052521e-01, 9.01273281e-01, 7.49090937e-01],\n",
+       "       [1.98641403e-01, 4.49672882e-01, 2.58717668e-01],\n",
+       "       [7.12504542e-01, 4.95576766e-02, 7.61240801e-01],\n",
+       "       [3.04487116e-01, 9.50210774e-01, 2.57841988e-01],\n",
+       "       [7.77291106e-01, 5.39120222e-01, 7.41063167e-01],\n",
+       "       [2.92830014e-01, 1.70029033e-01, 6.00037370e-02],\n",
+       "       [7.98603824e-01, 3.40237031e-01, 9.60862028e-01],\n",
+       "       [7.93814946e-01, 3.25874071e-01, 5.43655140e-01],\n",
+       "       [2.68565981e-01, 1.69799027e-01, 4.44632500e-01],\n",
+       "       [2.25509920e-01, 6.64324615e-01, 4.38710904e-01],\n",
+       "       [7.30509030e-01, 8.41605769e-01, 5.46991622e-01],\n",
+       "       [7.04560623e-01, 8.41692824e-01, 9.60516171e-01],\n",
+       "       [2.08225028e-01, 6.62225248e-01, 3.27568511e-02]])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lfp_strained.frac_coords"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15e61f60",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Diff in fractional coords:\n",
-      "[[-6.44295515e-05  4.42190331e-03 -8.88747675e-03]\n",
-      " [ 1.01354042e-02 -3.59713796e-03  4.00084024e-03]\n",
-      " [ 1.02735788e-02  2.84398857e-03 -6.87950406e-03]\n",
-      " [-6.30657207e-03  3.25853396e-03 -8.15319630e-03]\n",
-      " [ 2.55439830e-03  3.13837100e-04  2.73700429e-03]\n",
-      " [ 4.27699688e-03 -8.28934507e-04  5.22431816e-03]\n",
-      " [-5.10305099e-03  2.62811369e-04  1.27624838e-03]\n",
-      " [ 3.20187893e-03  1.12031331e-03  8.20301701e-04]\n",
-      " [ 1.36107513e-03  8.19890738e-04  2.87038964e-04]\n",
-      " [ 3.59550881e-03 -3.44683169e-04 -4.25391857e-03]\n",
-      " [ 3.56245404e-03  1.54407833e-04  3.12803116e-03]\n",
-      " [-7.94215693e-04 -2.07348846e-03 -8.65240814e-04]\n",
-      " [ 3.17932869e-03 -1.52997662e-03  1.28374732e-03]\n",
-      " [ 3.71227991e-03 -1.60643486e-03 -2.80079129e-03]\n",
-      " [ 2.40632945e-03  5.02697953e-04 -2.25687770e-03]\n",
-      " [-1.46934998e-03 -9.22684516e-05 -6.02061152e-03]\n",
-      " [ 1.12287755e-03 -6.49010452e-04 -1.19041894e-03]\n",
-      " [-1.19763132e-03 -1.78566718e-03  3.91931748e-03]\n",
-      " [ 5.54552805e-04  1.21783152e-03 -9.66906134e-03]\n",
-      " [ 4.04196582e-03 -1.51785027e-04 -6.30853076e-03]\n",
-      " [ 3.01130183e-03  5.33135594e-03  3.73326589e-03]\n",
-      " [ 1.97472795e-03  1.47753742e-03 -3.94291472e-03]\n",
-      " [ 7.49013079e-04 -8.74024263e-04 -4.03811006e-03]\n",
-      " [ 3.72393961e-03 -2.10889080e-03  3.88140477e-03]\n",
-      " [ 3.59698882e-03 -2.65895738e-03  6.33455850e-03]\n",
-      " [ 6.11865146e-05 -1.59177638e-03 -8.99243035e-04]\n",
-      " [-2.92065200e-03 -3.08716699e-03 -1.27346937e-03]\n",
-      " [ 3.44259661e-03  1.85818819e-03  6.14173325e-03]]\n"
+      "mean diff in frac. coords. between strained and original LFP structure: 0.00798\n"
      ]
     }
    ],
    "source": [
-    "print(f\"Diff in fractional coords:\\n{pbc_diff(lfp.frac_coords, relaxed.frac_coords)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d1b355f7",
-   "metadata": {},
-   "source": [
-    "Quite clealy, the relaxation using the M3GNet universal IAP has brought the lattice parameters much closer to the original DFT one and the coordinates are also within $10^{-3}$ of the original fractional coordinates."
+    "strained_to_orig_frac_coords_mean_diff = abs(pbc_diff(lfp_strained.frac_coords, lfp.frac_coords)).mean()\n",
+    "\n",
+    "print(\n",
+    "    \"mean diff in frac. coords. between strained and original \"\n",
+    "    f\"LFP structure: {strained_to_orig_frac_coords_mean_diff:.3}\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
+   "id": "96bd6e24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean diff in frac. coords. between original and M3GNet-relaxed LFP structure: 0.0026\n"
+     ]
+    }
+   ],
+   "source": [
+    "orig_to_m3gnet_frac_coords_mean_diff = abs(pbc_diff(lfp.frac_coords, relaxed_struct.frac_coords)).mean()\n",
+    "\n",
+    "print(\n",
+    "    \"mean diff in frac. coords. between original and M3GNet-relaxed \"\n",
+    "    f\"LFP structure: {orig_to_m3gnet_frac_coords_mean_diff:.3}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1e46851",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "M3GNet reduces the mean difference in frac. coords. from the strained to the original structure by a factor of: 3.07\n"
+     ]
+    }
+   ],
+   "source": [
+    "mean_pbc_diff_ratio = strained_to_orig_frac_coords_mean_diff / orig_to_m3gnet_frac_coords_mean_diff\n",
+    "\n",
+    "print(\n",
+    "    f\"M3GNet reduces the mean difference in frac. coords. from the strained \"\n",
+    "    f\"to the original structure by a factor of: {mean_pbc_diff_ratio:.3}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a064bd17",
+   "metadata": {},
+   "source": [
+    "# Phonon Band Structure and DOS\n",
+    "\n",
+    "The M3GNet IAP can also be used to compute the lattice vibrations in a super cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "71339aa0",
    "metadata": {},
    "outputs": [
@@ -204,23 +267,61 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING, 1 imaginary frequencies at q = ( 0.00,  0.00,  0.00) ; (omega_q = 3.625e-09*i)\n",
-      "WARNING, 1 imaginary frequencies at q = ( 0.00,  0.00,  0.00) ; (omega_q = 3.625e-09*i)\n"
+      "WARNING, 1 imaginary frequencies at q = ( 0.00,  0.00,  0.00) ; (omega_q = 4.480e-09*i)\n",
+      "WARNING, 1 imaginary frequencies at q = ( 0.00,  0.00,  0.00) ; (omega_q = 4.480e-09*i)\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "from ase.phonons import Phonons\n",
+    "from pymatgen.io.ase import AseAtomsAdaptor\n",
+    "\n",
+    "from m3gnet.models import M3GNet, M3GNetCalculator, Potential\n",
+    "\n",
+    "mp_129 = mpr.get_structure_by_material_id(mp_id := \"mp-129\")\n",
+    "\n",
+    "# Setup crystal and EMT calculator\n",
+    "atoms = AseAtomsAdaptor().get_atoms(mp_129)\n",
+    "\n",
+    "potential = Potential(M3GNet.load())\n",
+    "\n",
+    "calculator = M3GNetCalculator(potential=potential, stress_weight=0.01)\n",
+    "\n",
+    "# Phonon calculator\n",
+    "N = 7\n",
+    "supercell = (N, N, N)\n",
+    "ph = Phonons(atoms, calculator, supercell=supercell, delta=0.05)\n",
+    "ph.run()\n",
+    "\n",
+    "# Read forces and assemble the dynamical matrix\n",
+    "ph.read(acoustic=True)\n",
+    "ph.clean()\n",
+    "\n",
+    "path = atoms.cell.bandpath(\"GHPGN\", npoints=100)\n",
+    "bs = ph.get_band_structure(path)\n",
+    "\n",
+    "dos = ph.get_dos(kpts=(20, 20, 20)).sample_grid(npts=100, width=1e-3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "025d5dd9",
+   "metadata": {},
+   "outputs": [
     {
      "data": {
       "text/plain": [
-       "Text(0.5, 0, 'DOS')"
+       "Text(0.5, 1.02, 'Phonon band structure and DOS of LiFePO4 Mo1 (mp-129) with (7, 7, 7) supercell')"
       ]
      },
-     "execution_count": 17,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAewAAAEgCAYAAAB2AECvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAABkXElEQVR4nO3dd1gUV9vA4d9ZEAF7wYa9t9jFrthBDWrsPUajRk2iprymGVPefJrENGPX2GPvxhJ7L9gVxV4odkVRpO75/mDxJQYVdZfZhee+Li52ZmfOPIvCM3Oq0lojhBBCCPtmMjoAIYQQQjyfJGwhhBDCAUjCFkIIIRyAJGwhhBDCAUjCFkIIIRyAJGwhhBDCAdg0YSulfJRSp5VS55RSw5N4P71SaoHl/X1KqcKW/V5KqSOWr6NKqbaJzrmklDpuee+ALeMXQggh7IWy1ThspZQTcAZoCgQD/kAXrfXJRMcMBCporQcopToDbbXWnZRS7kC01jpWKZUXOArks2xfAqpprW/ZJHAhhBDCDtnyCdsLOKe1vqC1jgbmA62fOKY1MNPyejHQWCmltNYRWutYy35XQGZ3EUIIkabZMmF7AkGJtoMt+5I8xpKg7wE5AJRSNZRSAcBxYECiBK6Bv5VSB5VS/WwYvxBCCGE3nI0O4Gm01vuAckqpMsBMpdRarXUkUFdrHaKUygVsUEoFaq23P3m+JZn3A8iQIUPV0qVLp2j84p9u374NQI4cOQyOJPWQn6n1yc80aQcPHryltfZIvC9nzpy6cOHCBkWUeiX1s05gy4QdAhRItJ3fsi+pY4KVUs5AFuB24gO01qeUUg+A8sABrXWIZf8NpdQy4qve/5WwtdaTgckA1apV0wcOSP80I82YMQOAN99809A4UhP5mVqf/EyTppS6/OS+woULI39XrS+pn3UCW1aJ+wMllFJFlFIuQGdg5RPHrAR6WV63BzZrrbXlHGcApVQhoDRwSSmVQSmVybI/A9AMOGHDzyCEEELYBZs9YVt6dA8G1gNOwB9a6wCl1NfEPymvBKYBs5VS54A7xCd1gLrAcKVUDGAGBmqtbymligLLlFIJsf+ptV5nq88ghBBC2AubtmFrrdcAa57YNyLR60igQxLnzQZmJ7H/AlDR+pEKIYQQ9k1mOhNCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgFIwhZCCCEcgCRsIYQQwgHYNGErpXyUUqeVUueUUsOTeD+9UmqB5f19SqnClv1eSqkjlq+jSqm2yS1TCCGESI1slrCVUk7AOMAXKAt0UUqVfeKwPsBdrXVx4GdgtGX/CaCa1roS4ANMUko5J7NMIYQQItWx5RO2F3BOa31Bax0NzAdaP3FMa2Cm5fVioLFSSmmtI7TWsZb9roB+gTKFEEKIVMeWCdsTCEq0HWzZl+QxlgR9D8gBoJSqoZQKAI4DAyzvJ6dMLOf3U0odUEoduHnzphU+jhBCCGEcu+10prXep7UuB1QHPlFKub7g+ZO11tW01tU8PDxsE6QQQgiRQmyZsEOAAom281v2JXmMUsoZyALcTnyA1voU8AAon8wyhRBCiFTHlgnbHyihlCqilHIBOgMrnzhmJdDL8ro9sFlrrS3nOAMopQoBpYFLySxTCCGESHWcbVWw1jpWKTUYWA84AX9orQOUUl8DB7TWK4FpwGyl1DngDvEJGKAuMFwpFQOYgYFa61sASZVpq88ghBBC2AubJWwArfUaYM0T+0Ykeh0JdEjivNnA7OSWKYQQQqR2dtvpTAghhBD/IwlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcACSsIUQQggHIAlbCCGEcAA2TdhKKR+l1Gml1Dml1PAk3k+vlFpgeX+fUqqwZX9TpdRBpdRxy/dGic7ZainziOUrly0/gxBCCGEPnG1VsFLKCRgHNAWCAX+l1Eqt9clEh/UB7mqtiyulOgOjgU7ALeB1rXWoUqo8sB7wTHReN631AVvFLoQQQtgbWz5hewHntNYXtNbRwHyg9RPHtAZmWl4vBhorpZTW+rDWOtSyPwBwU0qlt2GsQgghhF2zZcL2BIISbQfzz6fkfxyjtY4F7gE5njimHXBIax2VaN90S3X4F0opldTFlVL9lFIHlFIHbt68+SqfQwghhDCcXXc6U0qVI76avH+i3d201q8B9SxfPZI6V2s9WWtdTWtdzcPDw/bBCiGEEDZky4QdAhRItJ3fsi/JY5RSzkAW4LZlOz+wDOiptT6fcILWOsTyPRz4k/iqdyGEECJVs2XC9gdKKKWKKKVcgM7AyieOWQn0srxuD2zWWmulVFbgL2C41npXwsFKKWelVE7L63RAK+CEDT+DEEIIYRdslrAtbdKDie/hfQpYqLUOUEp9rZTysxw2DcihlDoHDAMShn4NBooDI54YvpUeWK+UOgYcIf4JfYqtPoMQQghhL2w2rAtAa70GWPPEvhGJXkcCHZI471vg26cUW9WaMQohhHh1b731Fl26dKFp06ZGh5Jq2TRhCyGESBumT59ORESEJGwbsute4kIIIRxHXFyc0SGkapKwhRBCWEVsbKzRIaRqkrCFEEJYRVRU1PMPEi9NErYQQgiriIiIMDqEVE0SthBCCKu4d++e0SGkapKwhRBCWMX169eNDiFVk4QthBDCKq5evWp0CKmaJGwhhBCvrESJEkaHkOpJwhZCCPHKihYtCkBwcLDBkaRekrCFEEK8MmdnZ5ydnVm1apXRoaRakrCFEEJYReXKlRk9erRMoGIjkrCFEEJYReHChUmXLh1TpsgiirYgCVsIIYRVKKVo3rw5n376KQcPHjQ6nFRHErYQQgir8fDwoFmzZrRo0YLDhw8bHU6q8tTlNZVSw5Jx/kOt9SQrxiOEEMLBlS1bFq01DRs2ZMaMGbRp08bokFKFZz1hfwRkBDI94+sDWwcohBDC8ZQrV46OHTvSt29funXrxrVr14wOyeE99QkbmK21/vpZJyulMlg5HiGEEKmEp6cn/fr1Y9euXZQpU4bPP/+cwYMHkz59eqNDc0jPesL+6Xkna60/tmIsQgghUpn06dPTqFEjunXrxvTp0/H09GTkyJHcuHHD6NAczrOesI8opU4A84AlWuuwlAlJPE3w/WC2XtrKmdtnyOmekzwZ85AnYx6q5q1KBhep7BBC2C8PDw86dOjAjRs3WLduHWPGjKFdu3YMGjSIatWqoZQyOkS796yE7Qk0AToD3yml9hKfvFdorR+lRHACbkXc4tvt37L6zGrO3z2f5DFZ0mfhrcpvMaj6IIplL5bCEQohRPLlypULX19f6tevz6FDh/Dz88PFxYWePXvSrVs3SpcubXSIduupCVtrHQesB9YrpVwAX+KT9y9KqU1a624pFGOaFGeOY9rhaXyy6RPuR92nRYkWDPYajHdhb8rnKk9YZBjXHlzjcthl5hyfw9j9Y/ll7y/4lfJjfMvx5MuUz+iPIIQQT5UhQwbq1atH3bp1CQ0NZcuWLYwbN468efPSo0cP/Pz8KFOmjDx5J/KsJ+zHtNbRSqmTwCmgKlDGplGlcYG3Aum5rCf+of54F/bmd9/fKZer3D+Oyemek5zuOSmfqzwtS7ZkTLMxTDwwkTF7xlBxYkXmtJ1D8+LNDfoEQgiRPEopPD098fT0pHHjxly6dIkVK1YwZswY0qdPj5+fH23atKFBgwZpvrPaMxO2UqoA8U/VXYAMxFeJ+2mtA1MgtjTp6LWjNJ3dFIC5b8ylS/kuybrDzJcpH183/Jou5bvQcXFHfOb6MLzOcL5p9A3OpmTdlwkhhKFMJhNFixalaNGiaK25ceMGZ86cYeDAgVy7do0GDRrQqlUrmjVrRrFiaa/571kTp+wmvh17IfC21lrmmbOxA6EHaDa7GRlcMrC552ZK5Hjx9WXLeJRhX999vL/2fUbtGkXAzQCWdFxCOqd0NohYCCFsQylF7ty5yZ07N/Xq1ePhw4ecO3eOP/74g88++wx3d3eaN2+Or68vjRo1Inv27EaHbHPPevQaDuzQWuuUCiYt2xO0B5+5PmR3y87mnpspkq3IS5flns6dKX5TqJC7Au+te4/uy7rz5xt/4mRysmLEQgiRcjJkyEDFihWpWLHi46fv8+fPM3LkSHr27EmJEiVo0aIFzZo1o3bt2qmy+vxZnc62AyilSgITgNxa6/JKqQrEV4t/+7zClVI+wK+AEzBVaz3qiffTA7OIbxe/DXTSWl9SSjUFRgEuQDTwkdZ6s+WcqsAMwA1YA7zv6DcV5++cx2euD7kz5GZTz00UyFLAKuW+W+NdImMj+Xjjx7inc2ea3zRMSqaPF0I4tsRP3wCxsbEEBQWxZ88eFi1aRGhoKF5eXrRo0YKmTZtSsWJFTCbH/9uXnMbNKcRPUzoJQGt9TCn1J/DMhK2UcgLGAU2BYMBfKbVSa30y0WF9gLta6+JKqc7AaKATcAt4XWsdqpQqT3xvdU/LOROAt4F9xCdsH2Btcj6sPYqKjaLj4o44KSc29NhgtWSd4KM6H/Ew5iFfbfuKDOkyMNZ3rPS6FEKkKs7OzhQpUoQiReJrJh89esSlS5dYvnw5v/76K48ePaJp06b4+fnRvHlzcubMaXDELyc5Cdtda73/iT/yyVmd3As4p7W+AKCUmg+0BhIn7NbASMvrxcDvSimltU68xEsA4GZ5Gs8OZNZa77WUOQtogwMn7I83fMyhq4dY3mk5hbIWssk1vmzwJQ+jH/Ljnh8pn6s8A6oNsMl1hBD2QWudpm/M3dzcKFOmDGXKxA9oCgsL49y5c3z//ff069ePEiVK8Prrr9OyZUu8vLwc5uk7OQn7llKqGKABlFLtgavJOM8TCEq0HQzUeNoxWutYpdQ9IAfxT9gJ2gGHtNZRSilPSzmJy/QkCUqpfkA/gIIFCyYj3JS37NQyftv/G0NqDKF16dY2u45SitFNR3Pi5gneX/c+1fNVp2q+qja7nhAiZcSaY9lwfgMzj85kV9AuHkY/JCImghhzDGU9ylI9X3W8PL1oXqz5K/WLcXRZs2alWrVqVKtW7XH1+bZt25gxYwZRUVF07NiRbt26UbNmTbu+0UlOwh4ETAZKK6VCgItAikyaopQqR3w1ebMXPVdrPZn4uKlWrZrdtXFfDrvMWyvfolq+aoxuOtrm1zMpE7PbzqbypMp0WNSBg/0Oks0tm82vK1I3rTWbLm5iT9Aezt45y7k757gbeZeKuStSw7MGNfLXoIZnDenwaGVx5jhG7xrN2P1jufbgGtndsuNb3JdsrtlwT+eOSZk4duMYq86sYvqR6QDULViXnhV60qFcB7K6ZjX2AxjoyerzmzdvcvLkSTp06IDZbKZTp068+eabVKxY0eBI/+25CdtSpd3EsjKXSWsdnsyyQ4DEDbL5LfuSOiZYKeUMZCG+8xlKqfzAMqCn1vp8ouPzP6dMhzB47WBizbHMbzcfFyeXFLlmTvecLGy/kPoz6tN7RW+WdVpm13eTwn5FxEQw59gcftn7C6dunQIgf+b8lMheglI5SrE7aDcLAhYAUCVvFSa2nEh1z+pGhpxqXH9wna5Lu7L54mZalGhBn8p9aFmiJemd/90rWmvN+bvnWRSwiFnHZtFvdT+GrB9C99e6M8hrEBVyVzDgE9gXDw8PGjRoQP369blx4waHDx9m1qxZVKhQgS+++IKGDRvazd/Jp1bcK6VaJd7WWj98Mlk/ecwT/IESSqkilqlNOwMrnzhmJdDL8ro9sFlrrZVSWYG/gOFa612JYrgK3FdK1VTxP8GewIpnfUB7tP7celafWc2I+iNSfO7vWgVq8UPTH1hxegW/7P0lRa8tHJ/WmjnH5lDol0L0X90fV2dXZrWZxcNPHxI0NIjNvTazvPNyrgy9QuiwUKa3ns7V8KvUmFqDd9e8y73Ie0Z/BIe2/fJ2Kk+qzO6g3UxvPZ2/uv7FG2XeSDJZQ3xzWPHsxfmk3iecHHiS/X3307V8V2Yfm03FiRVpMKMBc47N4VGMLA+R0PO8YcOGDBw4kMyZM9O9e3cqV67M33//bXR4wLOX1/xBKVVZKVXlaV/Ad087WWsdCwwmvof3KWCh1jpAKfW1UsrPctg0IIdS6hwwjPix31jOKw6MUEodsXzlsrw3EJgKnAPO42AdzmLiYhi6fijFsxfnvRrvGRLD+zXe5/WSr/Pp5k85e/usITEIx3P9wXXeWPgGPZb1oET2EmzttZWD/Q7So2IP3NO5/+v4vJny8malNzk16BSDqg9inP84qkyuQsh9h6wUM9ymC5toPKsxGV0ysq/vPt6s9OYLna+Uorpndab4TSF4WDA/NP2B4PvB9FjWg7xj8jLor0FsubiFqNgo23wAB+Ls7EyVKlV4++23KVWqFF26dGH06NEYPYL4WVXi13n+mtjP/GuvtV5D/NCrxPtGJHodCXRI4rxvecqwMa31AaD8c+KyWxMOTODUrVOs6LziqXfFtqaUYmKriZQdV5a+q/qypdcWGZ8tnmn1mdX0XtGb8Khwfmj6A0NrDk12u3QW1yyMbTGWzuU74zvXl2ZzmrHtzW3kdHfMoTVGOHv7LB0WdaBUjlLsfGvnK7dBZ3fLzoe1P2RYrWFsu7SNaYenMe3wNMYfGI+bsxv1C9XHy9OLfJnykTdjXut8CAdkMpkoW7Ysnp6ejBs3jkuXLjFhwgTD4nnWxCneKRhHmnAr4hZfbv2SpkWb8nrJ1w2NJV+mfIxpNoa+q/oy+eBkGeolkqS15pe9v/DB3x9QKU8l5rwxh7IeZV+qrDoF67Cqyyp85vrgO9eXTT03kTl9ZitHnPqERYbx+rzXMSkTK7ustGqHMZMy0bBIQxoWaciElhPYdnkbG85vYMOFDfx9/m80dtdf1xBZsmShW7du/Pzzz/z000+4ubkZEoc8VqWgL7d8SXhUOD83/9kuOjG8VfktmhRtwscbPiboXtDzTxBpSqw5lkFrBjHs72G0LdOWnW/tfOlknaBB4QYs6rCII9eO4DfPj8jYSCtFmzrFmmPpvLgz5++eZ2mnpRTNVtRm18qUPhOtSrbiV99fOTnoJFGfRxEyLIQDbx+w2TUdiaurKzly5ODEiROGxSAJO4VcvHuRSQcn0b9q/38tlWkUpRSTW00mTsfRf3V/w9tnhP2IiInAb54fEw5M4OPaH7Oow6Ik26lfRquSrZjZZibbLm/jyy1fWqXM1Gr0ztGsP7+eCS0nUL9Q/RS9djqndOTLlE/mbLA4e/bs4ypyo0jCTiFj9ozBpEx8Wu9To0P5hyLZivBdo+9Ye24tS04tMTocYQceRD+g5Z8tWX9+PZNaTWJ009FW7+PQ9bWuvF3lbX7c8yMHQuUJLimXwi7x7Y5vaV+2PX2r9DU6nDQtJCSEtWvXMn36dDJkyGBYHM/9LVRKdVBKZbK8/lwptdTSQ1wk042HN5h2eBo9K/bEM3OSE7MZKmE85gd/f0BETITR4QgDhUeF4zvXl+2XtzO77Wz6Ve1ns2t93/R7cmfITZ+VfYiJi7HZdRzV0PVDMSkTPzV7Xt9fYStaa/bu3cvixYuZPHkyTZo0MTSe5Nw2f6G1DldK1QWaED8Uy7hucg5o7L6xRMVG8VHtj4wOJUnOJmfG+o7lyr0rjNo56vkniFTpXuQ9ms1pxp6gPcxvN5+ur3W16fWyumZlQssJHLt+jO93fW/TazmadefWsTxwOZ/X+9zqCwKJ5AkODmbu3LlcvXqVgwcP0q5dO6NDSlbCjrN8bwlM1lr/RfyylyIZwqPC+d3/d9qWaUupnKWMDuep6heqT9fXuvL9ru+5cPeC0eGIFPYw+iEt/2zJgdADLOqwiA7l/jXa0iZal25Nx3Id+Xr715y6eSpFrmnvomKjeHftu5TIXoJhtYYZHU6ac/v2bZYvX86KFSv4z3/+w8GDBx9PY2q05CTsEKXUJOKXvVxjWTVL2r6TafLByYRFhvGfOv8xOpTn+r7J9zibnBm6fqjRoYgUFBUbRdsFbdkTvIc/3/iTtmXapuj1f/P5jYwuGXlvnTETCdmbn/b8xLk75xjrO9awuRrSohs3brBq1SpmzpxJ27ZtuXjxIn379sXJyX7mwU9O4u1I/GxlzbXWYcQvcWmfdbt2Jio2ip/2/kSjIo3w8vQyOpzn8szsyRf1v2Dl6ZWsO7fO6HBECog1x9J5SWc2XNjA1NenptiTdWK5M+bm07qfsvHCRnYH7U7x69uT8Khwvt/9Pa+XfJ3mxZsbHU6aEBQUxOLFi1mwYAFt27blypUrjBgxwtDOZU/z3ISttY4AbgB1Lbtiec4MZyLen8f/JDQ8lOF1hj//YDsxpOYQSmQvwdD1Q6UjUCpn1mbeWvEWywOX85vPb/Su3NuwWAZUG4CHuwdfb/vasBjswdRDUwmLDOOzep8ZHUqqZjabOXXqFHPmzGHdunX079+foKAgPvvsM7JkyWJ0eE+VnF7iXwL/AT6x7EoHzLFlUKnFxIMTKedRjiZFje1Z+CLSO6fnx2Y/EngrkEkHJxkdjrARrTUf/f0Rs4/N5puG3/BujXcNjSeDSwY+rP0h68+vZ1/wPkNjMUp0XDQ/7f2JBoUaUCN/DaPDSZWio6Px9/dn8uTJnD59mu+++45Lly4xePBgw2YvexHJqRJvC/gBDwG01qFAJlsGlRocu36M/SH7ebvK23Yxq9mLeL3k6zQq0ogvt37J3Ud3jQ5H2MCPu3/kp70/8a7Xu3bzNDew+kByuOXg6+1p8yl73vF5BN8Pdoj+Lo4mIiKC7du3M27cOOLi4li0aBGHDh2iQ4cOODs/d5Vpu5GchB2t46fA0gCWdbHFc0w9NBUXJxe6V+hudCgvTCnFT81+4u6ju3yz/RujwxFWNvPITD7e+DEdy3XkF59f7OaGMqNLRobVGsaas2vwD/E3OpwUZdZmvt/9PRVyV8CnuI/R4aQa9+/f5++//2bChAnkz5+fPXv2sHbtWurWrWs3/+9fRHIS9kJLL/GsSqm3gY3AFNuG5dgexTxi9rHZtCvTjhzuOYwO56VUzFORPpX78Pv+32UJzlRk7dm19FnZh8ZFGjOrzSy7W6VtsNdgsrlmS3M3in+d+YuTN0/yce2PHTKR2JuERD1lyhSqV69OYGAgM2fOpEyZMkaH9kqS0+nsR2AxsAQoBYzQWo+1dWCObOmppYRFhjn8dILfNPqG9M7p+Xjjx0aHIqzgQOgB2i9qT4XcFVjaaaldDhnKnD4zQ2oOYdWZVWlqXPboXaMplKUQncp3MjoUhxYZGcnGjRuZMmUKXl5enD17ll9++YV8+fIZHZpVJOv2Wmu9QWv9kdb6Q631BlsH5eimHp5K0WxF8S7sbXQoryRPxjx8WvdTlgcuZ/PFzUaHI17B+TvnaflnS3JlyMWabmvselnLAdUGkM6UjskHJxsdSoo4cu0Iu4J2MaTmEJxNjtOeak/MZjOHDh1i0qRJFC9enDNnzvDzzz+TO3duo0OzqqcmbKXUTsv3cKXU/URf4Uqp+ykXomM5e/ssWy9tpW/lvnZX3fgyhtYaSuGshRmybgix5lijwxEv4ebDm/jM9SHWHMu6buvIkzGP0SE9U64MuWhTug0zj85ME8tvTj88HRcnF3pW7Gl0KA4pLCyMOXPmEBISwoYNG5g+fTp58tj3//GX9dSMorWua/meSWudOdFXJq21/d6eG2za4Wk4KSferPSm0aFYhauzK2OajeH4jeNMOShdFxxNREwEr897neD7wazustqup8dNrF/VftyNvMuSk6l7Bbmo2CjmHJ9Dm9JtyO6W3ehwHE5gYCAzZsxgwIAB7N+/n6pVU/dSoMkZh509ia90KRGco4k1xzLjyAxalWxF3kx5jQ7HatqWbkvDwg35YssX3Hl0x+hwRDLFmmPpvLgz/qH+zGs3j1oFahkdUrI1KtKIotmKMvlQ6q4WX3l6JXce3eGtSm8ZHYrDOXLkCFu2bGHNmjV89NFHmEyOX6P5PMn5hIeAm8AZ4mc4uwlcUkodUkql7tuZF7T10lauP7ye6qq2lFL84vMLdyPv8tXWr4wORySD1prBawaz6swqxvqOpU3pNkaH9EJMykS/Kv3Yfnk7gbcCjQ7HZqYfmU7+zPkdanIle3D+/Hm2b9/O1q1bqVXLcW5EX1VyEvYGoIXWOqfWOgfgC6wGBgLjbRmco1kYsJCMLhnxLe5rdChWVyF3BfpX7c84/3GcvHnS6HDEc3y34zsmHZzE8DrDGVh9oNHhvJQ3K72Js8k51TbFBN8PZv359fSq2Asnk/0sMGHvtNasW7eOBQsWULp0aaPDSVHJ6ZJYU2v9dsKG1vpvpdSPWuv+lpW7BBATF8OSU0vwK+WHWzr7n+LuZXzd8GvmnZjHoDWD2Nxzc5ocL6q1JjQ8lP0h+zl+4zhnbp8h5H4I4dHhPIh+QERMBBqNCRNKKdI7pSerW1ZyuOUgT8Y8VMhdgXoF61EpTyWb/ZGeeWQmn2/5nO4VuvNd4+9sco2UkDtj7sedz/7b+L+4OrsaHZJVzTo6C7M2p5r+LiklODiYzJkz07hxY6NDSXHJSdhXlVL/AeZbtjsB15VSToDZZpE5mM0XN3Pn0R06lUu94yhzuufk+ybf0291P6Yfmc5blVN3u5vWmoCbASwIWMDmC5s5f/c8tyJuEafjkjzepEw4KSeUUsRPDghxOg7znaR/TTKky0Dx7MWpW7Aunct3pm7Bukke9yLWn1tP31V9aVK0CdP8pjn8TVW/Kv1YfHIxy04to8trXYwOx2q01kw/Mp36hepTPHtxo8NxKHfv3qVs2bIO/3/7ZSQnYXcFvgSWEz896S7LPifil94UwIKABWROn5lmxZoZHYpN9anShznH5/DB3x/QokQLux8i9KIu3LnAlENTWHF6BWfvnP3HULZ0pnTkyZiHkjlKUt6jPOVylaNynsqUz1Uedxf3p5apteb6g+ucunWKvSF7OXL1CGdun+FC2AWOXj/K0etHGec/DhcnF8p7lKdT+U4Mrj74mWUm5dDVQ7Rb2I5yHuVY0nEJLk4uL/1zsBeNizamQOYC/Hniz1SVsHcF7eLcnXN8Xu9zo0NxOHnz5mXZsmVordNc0n5mwrY8Rf+qte72lEPOWT8kxxMdF82ywGW0LtU61VXbPcmkTExuNZmKEyvy/rr3WdB+gdEhvRKtNdsvb+fnvT+z5dIW7kf9b4qBHG45qJSnEi1LtKR92fYUyFLgpa6hlCJPpjzkyZSHhkUa/uO9RzGPWHl6JQsCFrD98nYOXTvEoWuHGL5xOOVzlWdozaH0qtjruT1gL969SIu5LcjhnsPuJ0Z5ESZlomO5jvy27zfuPrpLNrdsRodkFQtOLMDV2ZV2ZdsZHYrDyZEjBy4uLvz000988MEHRoeTop75V0BrHQcUUko5/q26DW28sJGwyLBUXR2eWKmcpfii/hcsDFjIqtOrjA7nhWmt2XhhI01nN8X9O3e8Z3qz4vQKImMiqZ6vOj82/ZEbH97g1se32NhzI0NrDX3pZP08bunc6FS+E0s7LeXWx7e48eENPqn7CZ6ZPTl+4zhvrXwLt+/c6LakGzcf3kyyjJsPb9J8TnOi46JZ120d+TKljmkYE3Qs15EYcwwrTq8wOhSrMGszSwOX4lPch4wuGY0Ox+GYTCZat27NN998w4YNaWvizeRUiV8AdimlVmJZYhNAa/3T805USvkAvxJffT5Vaz3qiffTA7OAqsBtoJPW+pJSKgfx85dXB2ZorQcnOmcrkBd4ZNnVTGt9Ixmfw2YWBCwgq2tWmhZramQYKeqjOh8xP2A+A9cMpE7BOik+6cP5O+dZe24tJ2+e5NStU5y5fQZXZ1dyZchFrgy5KJ2jNB3KdaBq3qqP25S3Xd7GD7t/YOulrUTERADgns4d32K+vFfjPZoVb2b47HQeGTz4rvF3fNf4O67cu8KILSNYdHIRf574k3kn5uHl6cXU16dSPnd5ACLNkbT8syVB94PY1HMTZTwce3GDpFTPV51CWQqxMGBhquigtTd4L6HhobQrI0/XLytbtmy0bduWjh078sUXXzB06NA0UT2enIR93vJl4gXWwbZUp48DmgLBgL9SaqXWOvGYoD7AXa11caVUZ2A08Z3aIoEvgPKWryd101ofSG4sthQVG8XywOW0K9MuVbQZJpeLkwt/+P1BnT/q0G1pN1Z3WW3zoSlhkWEsDFjIrKOz2BW0C4As6bNQ1qMsTYs2JcYcw82HN7kUdom1Z9fy/e7vKZSlEJnSZ+L8nfM8io2/x3NzdqNF8RYMrzucugXtd5m9glkKMqPNDP7w+4OJByfy3Y7v2Beyj9cmvoZXPi9e16+z8O5CAqICWNZpGbUL1DY6ZJtQStGxXEd+3vsztyNuO+wKeAmWnFxCOlM6Xi/5utGhOLTChQvTq1cvfvnlF3bs2MH48ePJmzf1TFiVlOcmbK31VwBKKXetdcQLlO0FnNNaX7CcPx9oDSRO2K2BkZbXi4HflVJKa/0Q2KmUsvvuk3+f/5v7UffpWC7t9b+r7lmdsb5jGfDXAL7c+iXfNvrWJte58+gOP+35id/2/UZ4dDhlcpZhVONRdCrfiUJZCv0r4d6OuM3nWz7nz+N/cvneZQAUikq5KzGm2RgaFmlot0k6KSaTiYHVBzKw+kD+Pv83/Vf3Z3/ofvazH4BffX7Fr5SfwVHaVqdynfhh9w8sD1xOnyp9jA7npWmtWXJqCU2LNSWLaxajw3F42bJlo0ePHuzcuZMyZcrw5Zdf8u677+LsnDoXUUnO1KS1lFIngUDLdkWlVHImTPEEghJtB1v2JXmM1joWuAck5/Z5ulLqiFLqC/WUv7xKqX5KqQNKqQM3bybd9mcNywKXkdU1K42LpL0xgRA/53Ofyn34747/sjxwuVXLvhd5jy82f0HhXwrz3x3/xbeEL/v77idgYAD/qfsfCmct/DjxhkeFM2LzCIr8WoScP+Rk4oGJPIh+QJU8Vfi24bdUzFORI9ePMGT9ELZe2mrVOFNSs2LNuPj+RdqV/l916gd/f8AnGz/BbE69oyyr5K1C0WxFWXhyodGhvJKDVw9y+d5lqQ63IhcXFxo1akT37t2ZOHEiZcqUYfHixany9yE5DXa/AM2Jb2NGa30UqG/DmJ6nm9b6NaCe5atHUgdprSdrratprat5eHjYJBCzNvPX2b/wLe5LOqe0Ob26UorfW/xO9XzV6bmsp1XWMI6KjeKXvb9Q7LdifLvjW5oXb87xd46zoP0CqntWf5yk7zy6wyebPqHYb8XIPCoz3+z4hsthlymdozQ/NP2BR5894mD/g3xW/zMO9jvI/HbziYiJoPGsxny19SvizEmPp7Z3P+z6gSWBS2iYsSEds3bESTkxatcocv2Yi+2Xthsdnk0opehYtiObLmx6auc7R7Dk5BKclBOtS7U2OpRUx8PDgy5duuDl5cWHH35IuXLlWL58+eM5EVKD5K6HHfTEruT8pQsBEnetzW/Zl+QxSilnIAuWG4NnxBJi+R4O/El81bshDoQe4MbDG7Qq2cqoEOyCq7MrSzouwS2dG/Vn1Gf75ZdLGrHmWGYfnU2ZcWUYun4oVfJW4VC/QyzqsIjyueK7MhwMPUivZb3INyYfOb7Pwaido7h49yLFshVjZIORhH8SzqnBp/iw9of/6FNgUiY6le/E0QFH6V6hOyO3jcRnrg83HhraX/GFTTs0jY83fkyncp3onr07vll8CRsexhul3+D2o9s0mNmA9gvbp8qlUDuV70ScjmNZ4DKjQ3kpCdXhDYs0dPh2eHullKJkyZK8+eabVK5cmffff5/SpUszc+ZMoqOjjQ7vlSUnYQcppWoDWimVTin1IZCcxyh/oIRSqohlWFhnYOUTx6wEelletwc262fcDimlnJVSOS2v0wGtgBPJiMUmVp9ZjUmZ8CnuY1QIdqNAlgLs6L2DHG45aDyrMZMOTEr2uVGxUUw+OJlSv5ei5/KeZHHNwvru6/m7x99kSp+J4RuHU3lSZdz+60a1KdWYdWwWNx7eoKxHWUY1HsWDTx9w7r1zfOn9JRlcMjzzWhlcMjCzzUymvj6VnVd2UmVSFY5cO/KKnz5lLApYRL/V/fAp7sOstrMe92h3dXZlSacl7O2zl5zuOVlyagk5vs/B5oubDY7YuirmrkiJ7CVYEOCYY/9P3DjB2TtnpTo8BSilKFWqFL1798bLy4tRo0aRP39+/u///o+wsDCjw3tpyUnYA4BBxLc3hwCVLNvPZGmTHgysJz7BL9RaByilvlZKJfSQmQbkUEqdA4YBwxPOV0pdAn4C3lRKBSulygLpgfVKqWPAEUs8hq0MsPrMauoUSPkhTfaqZI6S7Ou7j6ZFmzLgrwG8vfJt9gXvIyYu5l/Hxppj2XJxC++ueZfCvxam/+r+uJhc6PZaN/JlzMfbq97G5RsXSowtwehdozly7Qhuzm74FPdhacelRH8e/bgt2z3di80IppSiT5U+7OmzB5MyUW96PdadW2etH4NNrAhcQdelXaldoDaLOyxOckRCjfw1uP7BdfpW7kt4VDiNZzVm4F+OufBHUpRStC/bnm2XtnH30V2jw3lhi08uRqEcbuU0R6aUonjx4nTu3Jk33niDxYsXU6BAAfr168fJk463iJFKTfX7T1OtWjV94IB1R4GF3A8h/8/5Gd1kNB/X+diqZTu68Khw3l719uMnIWeTM5lUJkyYMKU3ERkbSURMxFPn5AZwUk7kypCL8rnK06ZUG3pU7EGm9MkeVZhsoeGhtPyzJcevH2diq4n0rdLX6td4VevPrcdvvh+V8lRiQ48Nj2cxmzFjBgBvvvnmv87ZE7QHn7k+3I+6T7Fsxdj51s5UMY3s7qDd1PmjDvPbzadTeetPVPSsn+mrqjKpCu7p3Nn51k6rl21rSqmDWutqifc9+Xe1VatWZMiQgbJly6Z4fC/i/v37HD58mMOHD1OhQgU+/PBDWrRogZOTfayYltTPOsFz+74rpTyAt4HCiY/XWqfulR+e46+zfwGk+fbrOHMc68+vZ86xOewK2sW1B9eIjvtnW1GsOZa7WJ6IEg0MdFJOuKdzJ4trFvJnyk9pj9JUzVOVJkWbUNojZZbNy5cpH9vf3E6HRR14e9XbBN0LYqT3SLsZ9rXl4hbaLGhDWY+yrOu2LtlTjtYqUIvrH16n+ezmbL+ynUI/F2Jpp6W0LNnSxhHbVg3PGuRwy8Hqs6ttkrBt5dqDaxy+dpj/Nvqv0aGkeZkzZ6ZBgwbUqVOHgIAA3n//fQYMGMDgwYN5++23yZkzp9EhPlVyBqutAHYAG0leZ7M0YfWZ1RTJWoQyOVPfzFLPExkbyW/7fuOPw39w9s5ZzDp++IRJmfBw96BgloKUyVmGCrkrkM0tG5ldMrNr2y4yO2Wmf9f+ZHTJiHs6d5xN9jFWMlP6TKzqsor+q/vz9favuf7wOuNajDN8jeK/z/9N6/mtKZqtKH93//uF59F2dXZlW+9t/LL3F4atH0area0YXmc4/9fk/2wUse05mZzwKe7D2rNriTPHGf5vlFwJTS4tSrQwOBKRwNnZmYoVK1KxYkVCQkJYunQp3333Ha+//jpDhgzBy8uw/sxPlZy/mO5a6//YPBIH8ijmERsvbKRvlb528ySWElaeXsnnmz/nxI0TaOKbUgpkLkDDwg3pUaEHjYo2eurUng/8HwDY7TzX6ZzSMc1vGrky5GL0rtHcirjFnDfmGLaYy6rTq2i/qD1lcpZhQ48NeGR4+aGJQ2oOoVb+WjSe1ZhRu0axM2gnW3ptsZsbphfVqmQr5h6fy/6Q/dQqUMvocJJl7bm15M2Yl4q5KxodikiCp6cnnp6eNGrUiMOHD9OqVSvy5s3L0KFD6dSpE25ubkaHCCSv09lqpZTcFiay5dIWHsU+ShPV4VGxUXz090dkG52N1vNbc/zGcfJnzs9HtT/i9se3uTL0CjPbzqRJsSaGz8P9qpRSjGoyip+a/cSSU0vwmeNjSOemJSeX8MbCN6iYuyKbe21+pWSdoEb+GgQPC6ZE9hLsvLKTwr8U5k7EHStEm/KaF2uOk3Ji9ZnVRoeSLLHmWP4+/zc+xX3S1A2+I3J3d6dOnTq88847lC9fnh9++IF8+fLxwQcfcOnSJaPDS1bCfp/4pB2plLqvlApXSt1/7lmp2Oozq8mQLgMNCjUwOhSbiY6LZtCaQWT6v0z8uOdHwqPC8SnuQ+CgQK4MvcL3Tb9Ptb3jh9Yaypy2c9gdtJvaf9Tm4t2LKXbtsfvG0nFxR2p41mBDjw1W/Rlndc1K4KBA/Er6ERIeQqFfCxFwI8Bq5aeUbG7ZqFOwzuN+JPZub/BewiLDpDrcgZhMJkqWLEnHjh3p2bMn+/fvp2LFivj6+rJx40bDJmN5bsLWWmfSWpu01q5a68yW7dSx2O5L0Fqz+sxqmhVrRnrn9EaHY3Vx5jiGrR9Gpv/LxHj/8ZiUiWE1h/Hw04es7baWUjlLGR1iiuhWoRsbemzg+oPr1JxWk33B+2x6vThzHO+tfY/31r3H6yVfZ3339TaZa9pkMrGiywo+rv0xD6IfUGlSJdacXWP169hayxItOXr9KMH3g40O5bnWnl2Lk3KiSdEmRociXkL27Nlp0qQJgwcPxtnZmd69e1OiRAkmTpxIRMSLLK/x6pIzl7hSSnVXSn1h2S6glLK/1vgUEngrkKD7QfgW9zU6FKtbfHIxOb7Pwc97f0ahGFpzKA8+ecCY5mNS5c3J8zQo3IA9ffaQ0SUj3jO9mX54uk3urMOjwmmzoA1j949lWM1hLOm45LkTwLyq0U1H84ffH8SZ42j1ZytmHZ1l0+tZW0Jz1F9n7P8pe+25tdQuUJusrlmNDkW8AhcXF6pVq0afPn2oW7cu48aNI3/+/AwfPpzQ0NAUiSE5VeLjgVpAV8v2A+KXzUyTNl7YCJCq1r6+HHaZihMq0mFRB+5H3afba924/8l9fmr+E85OjtkxyVpK5SzF3j57qZW/Fm+tfIsey3oQHhVutfJ3B+2m0qRKrD27lvEtxjOm+ZgU6/ncu3JvNvbciJPJiV7Le/HTnucucW83yuQsQ+Gshe2+Wvxq+FUOXzss1eGpiFKKIkWK0L59e7p378727dspXbo03bt3JzAw0KbXTk7CrqG1HkT8GtVore8CaWfh5ydsuLCB4tmLUzhrYaNDsYrvtn9Hsd+KcezGMcp7lOfMu2eY88acNLW29/N4ZPBgQ48NfO39NfNOzKPq5KqvXEUeHRfNZ5s+o970emit2frmVt6p/o6VIk6+RkUasa/vPtI7pX+86pcjUErRskRLNl3cxKOYR0aH81QJw7lSY42cgBw5ctC8eXPeeecdrl27Rs2aNWnVqhX+/v42uV5yEnaMUsoJ4sfxWCZSSX3rliVDTFwMWy9tpUkRx2+LCr4XTJnfy/DZls9wMjnxh98fHB94nOLZ7X4JckM4mZz4osEXbOm1hYiYCGpOq0mXJV24cPfCC5UTZ45jYcBCKk+qzHc7v6N3pd4cHXCUugXr2ijy56uStwoBAwPImC4jo3aN4r217xkWy4toVbIVETERbLu8zehQnmrtubXky5SPCrkrGB2KsCF3d3fq1avHoEGDMJvNtGjRgqZNm3Lo0CGrXic5Cfs3YBmQSyn1X2An8J1Vo3AQ/qH+hEeHO3znkRlHZlDktyIE3g7EK58X1z64Ru/KvY0OyyHUL1Sfk4NO8nm9z1l5eiWlfy/NwL8Gsv3y9meukBUWGcbso7N5bcJrdFrcCa01KzqvYKrfVJtMufqiimUvxtn3zpIlfRbG7h/LoDXPXS7AcPUL1cfFyeVxM5W9iTPHseHCBnyKyXCutMLFxYUaNWowYMAAXFxcaNKkCa1bt+bUqVdfdhiSMXGK1nquUuog0BhQQButtXWu7mA2XtiIQtGwSEOjQ3kpceY42i9sz/LTy3FSTkxoMYEB1QcYHZbDyZw+M980+oZ3qr/Dl1u+ZOqhqUw4MIHsbtnxKe5DoSyFSO+UnvTO6bkafpXtV7Zz9NpRNJryucqzoP0C2pVpZ3ezdOXJmIczg89QalwpxvuPx2w2M6HVBKPDeir3dO7UKVDHbhP2oauHCIsMo1mxZkaHIlKYs7MzXl5eVKpUCX9/f2rWrEnfvn356quvyJgx48uXm5yDtNaBgG1b0x3AhgsbqJqvqkOOP74Udola02px7cE18mTIw64+uyiarajRYTm0fJnyMcVvCmOaj+Hv83+z6swq1p9bz+1Htx8/bbs5u1GrQC2+bPAl3oW9qVeonl1PMJMrYy7OvnuWkmNLMvHgRLTWTHx9otFhPVWTok34bPNn3Hx40yoTzFhTwvKm3oW9jQ1EGMbFxYU6depQoUIFtmzZ8ng4WOvWrV+qvLTdBfgFhEeFszd4Lx/V/sjoUF7Y2rNraT2/NTHmGFqXas2Sjkvs7unOkWVOn5n2ZdvTvmz7x/vizHFEx0XjbHImnVM6A6N7cTndc3Lm3TOUHFuSSYcmkSl9Jn5o9oPRYSUpIWFvvrjZ7hYD2XRxE+VzlSd3xtxGhyIMlilTJvz8/Lh48SJvv/02W7Zs4ccff8TZ+cVSsP3e6tuZhDZKR2u//mbbN7T4swWx5ljG+Y5jeeflkqxTgJPJCbd0bg6XrBPkdM/JyUEnyeQSP9PdV1u/MjqkJFXNW5Us6bPYXbV4VGwUO6/spFHhRkaHIuxIkSJF6N27N+vXr6dBgwbcu3fvhc6XhJ1MGy9sxNXZldoFahsdSrKYzWb85vkxYusIXJ1d2dF7BwO9BhodlnAgeTLm4fg7x3FzdmPktpF2OU7byeREwyIN2XBhg2HTRSZlX8g+HsU+olERSdjin9zd3enYsSOxsbF06NCBuLjkL4IpCTuZNlzYQL2C9QxbvelFRMdGU2lSJVadWYVnJk8uvX+JOgXrGB2WcECFshbicP/Dj8dpzzk6x+iQ/qVJkSZcvnf5hYfY2dLmi5sxKRMNCqfe9QbEyzOZTDRv3pzLly/z9ddfJ/88G8aUalwNv0rAzQCaFrX/2c3uRNyhyG9FOH7jONXyVuPSkEvShiZeSamcpdjdZzdOyomey3uy6cImo0P6h4Rmqk0X7SeuTRc3UTVvVZmOVDyVk5MTTZo0YcqUKcmuHZKEnQwJfwjsvf36/J3zFP61MKHhobQp1Qb/fv4Ou+axsC9V8lZhVZdVAPjM9eHY9WMGR/Q/JXOUJH/m/HbTjv0w+iF7g/dKdbh4Lg8PDyIjI7lwIXm1Q5Kwk2Hzxc1kd8tOxTz2u/j88evHKTe+HOHR4QypOYRlnZcZHZJIZXxL+DLNbxqx5lhqTq1pNytlKaVoUrQJmy5uwqyNn4Rx55WdxJpjJWGL53r06BFRUVHky5cvWcdLwk6G7Ze3U79QfbsdP7sveB9VJ1clKi6K0U1G83Pzn40OSaRSvSv35puG3/Ao9hGVJlYiMjbS6JAAaFykMXce3eHItSNGh8Lmi5tJZ0pHnQLSb0Q824EDB/D29sbNzS1Zx9tnBrIjIfdDOH/3PPUL1jc6lCRtvriZOn/UIcYcw/gW4/m4zsdGhyRSuc/rf07PCj25/eg2VSZVwWw2/qm2cZHGAHbRvr7p4iZqFahl8yVShWM7evQogYGBTJkyJdnnSMJ+ju2XtwPx8xbbm00XNtF0dlPM2szsNrMNWe1JpE0z286kpmdNTt06Rev5LzdrkzXlzZSXsh5lDe94dvfRXQ5dPSTjr8VTxcbGsmXLFnbu3MnGjRuTXR0OkrCfa9vlbWRyyUSlPJWMDuUftl7aSvM5zdFas6jDIrpX7G50SCKN2fHWDvJnzs/qs6v5eIPxNTvehbzZFbTrmYuw2Nr2y9vRaIddb0DYVkhICDNmzCBTpkycOHGCMmXKvND5krCfY/vl7dQtWNeuZgfbdWUXTWY1wazNzG8/n3Zl2xkdkkiDnE3OHO1/lIwuGflh9w8sOLHA0HgaFG7Ag+gHHL562LAYdlzZgYuTC16eXobFIOzPtWvXWLp0KcuWLeO7775j5cqV5MqV64XLkTE/z3Dj4Q1O3TpFr4q9jA7lMf8Qf7xnesdXg78xm47lOhodkkjDsrtnZ9dbu6gyqQrdlnajfK7ylMtVzpBY6hWsB8TfZFf3rG5IDDuu7MDL08shJlh6lpsPb3Lh7gXuPLrD7Ue3jQ7HYYWEhLBv3z5CQ0P55JNPGDBgAO7u7i9dnk0TtlLKB/gVcAKmaq1HPfF+emAWUBW4DXTSWl9SSuUAFgPVgRla68GJzqkKzADcgDXA+9pGcxLuuLwDsJ/269O3TlN3el1izbHMaD2Dbq91MzokIaiQuwIzWs+gx/Ie1P6jNiHDQsjo8vJLCL6svJnyUiJ7CbZd3sYHtT9I8es/iH7AwdCD/KfOf1L82q/q4t2LjPMfx9ZLWzlz+wzh0eFGh+SwYmJiOHHiBEePHiUmJoZhw4a9cqJOYLOErZRyAsYBTYFgwF8ptVJrfTLRYX2Au1rr4kqpzsBooBMQCXwBlLd8JTYBeBvYR3zC9gHW2uIzbL+8Hfd07lTNV9UWxb+Q0PuhVJlchei4aH7z/Y1eleznqV+I7hW7sz90P2P3j6X65OoEDAzAZEr5Frf6heqz5NQSzNqc4sMw9wbvJU7HUa9QvRS97su69fAWn2/5nOWBy7n+8Prj/U7KiUJZClEkWxFyuuUkp3tOJmK/S6zai+vXr3P8+HGOHTuGl5cXv//+Oz4+Pjg5Wa851ZZP2F7AOa31BQCl1HygNZA4YbcGRlpeLwZ+V0oprfVDYKdSqnjiApVSeYHMWuu9lu1ZQBtslLC3Xd5Grfy1cHFysUXxyXYv8h7lJpQjIiaCL+p9wbte7xoajxBJ+c33Nw6GHmR38G56Lu/JnDdSft7xBoUaMO3wNE7cOEGF3BVS9No7Lu/ApEx2v0DQiRsnGPTXIHZc2YFGo1CU9ShLzwo9aVe2HUWzFf3XzY4k7KQ9fPiQEydOcOrUKSIiIujVqxczZ86kaNGiNrmeLRO2JxCUaDsYqPG0Y7TWsUqpe0AO4NYzykw8vVKwZd+/KKX6Af0AChYs+KKxc/fRXY5dP8ZX3sYuKxgdG03Z8WUJiwxjQNUBfN0o+RPFC5HStvTagufPnsw9PpfGRRrTu3LvFL1+QvPVtkvbUj5hX9lBxdwVyZw+c4peN7nO3j5Lh0UdOHr9KAC5M+Tmo9ofMbD6QNzSJW/iDhFf5X327FkCAwO5cOECvr6+TJ48mUaNGln1aTopqbbTmdZ6MjAZoFq1ai/cxr3zyk402tD2a6011adWfzw3+IRWEwyLRYjkcHF2YW+fvZQeV5q3V72Nl6dXinZCK5S1EAWzFGT7le28WyPlaqKi46LZG7yXt6u8nWLXTK77UffptbwXKwJXoNGUzFGSX5r/gm8JX6NDcxhms5lLly4RGBjIyZMnqVixIu+//z7t27cnc+aUu0GzZcIOAQok2s5v2ZfUMcFKKWcgC/Gdz55VZv7nlGkV2y9vN3x4Ruv5rTl2/RhV81aVucGFwyiWvRiz2syi69Ku1J1el6sfXE3RXtMNCjVg/fn1aK1RSqXINQ9dPcSj2Ed213499dBUBq0ZRHRcNNndsjOl1RTeKPuG0WE5BK01165dIyAggJMnT5InTx569+5Nly5d8PRMsmLX5myZsP2BEkqpIsQn1c5A1yeOWQn0AvYA7YHNz+rxrbW+qpS6r5SqSXyns57AWFsEv+3yNmp41jCsqmjY+mGsOrOK/Jnzs6fPHkNiEOJldXmtC1subWHKoSl4z/Bmb9+9KXbt+oXqM/vYbE7fPk3pnKVT5JoJI0oShpYZ7VbELVrPb83uoN2YlIlP637KN42+sdv1EOzJ3bt3OXHiBIGBgQD06NGDyZMnv/AkJ7Zgs4RtaZMeDKwnfljXH1rrAKXU18ABrfVKYBowWyl1DrhDfFIHQCl1CcgMuCil2gDNLD3MB/K/YV1rsUGHswfRDzh09RDD6w63dtHJMsF/Aj/v/ZlMLpk4PuA46ZzSGRKHEK9i8uuT2XFlB/tC9jFyy0hGNhyZItdNaMbafnl7yiXsKzsomaOkXaw9vyJwBZ2XdCYyNpICmQuwqecmSuQoYXRYdi0yMpKTJ09y6tQpbt68SYcOHfj666+pVatWitXSJIdN27C11muIH3qVeN+IRK8jgQ5PObfwU/Yf4N9Dvaxqf8h+4nQcdQvWteVlkrTj8g4GrRlEOlM6DvY7SFa3rCkegxDWsqv3Ljx/9uTr7V/TvHhzahWoZfNrlshegjwZ87D98nb6Ve1n8+uZtZmdV3byRhljq5rjzHF8+PeH/LLvFwAGVhvIr76/4mxKtV2VXonZbObixYsEBARw+vRpGjRowPfff0+LFi1wcTF2ZNDTyL9kEnYH7QagZv6aKXrd0PuhNJ3dFI1mRZcVclcsHF529+ys7LySZnOa0WxOM65/cB13l1efQOJZlFLUL1SfbZe3pUg7dsCNAO5G3jW0OvxWxC1azm3J/tD9pDOlY1GHRbQubfyiLPbowYMHHDlyhKNHj5IzZ0769+9P165d8fDwMDq055IGjSTsDtpNOY9yZHXNmmLXjI6LpvLkykTFRTGq8Sh8i0sPTpE6NC3WlCE1hvAg+gH1Z6TMqIv6BesTfD+YS2GXbH6tHVcs7dcGdTg7d+cc5ceXZ3/ofjzcPTg64Kgk6ydorbl48SLLly9n4sSJ5MuXj7/++ouAgADef/99h0jWIAn7X8zazJ7gPSk++UG9P+px4+ENOpbtyH/qOt7UhkI8y88+P1POoxwHrx7k6222n0ugTsE6wP9qy2xpV9Au8mbMS5GsRWx+rSftCdpDpYmVuP7wOpXyVCJwcCBlPIzvHGUvYmNjOXLkCNOnT2fnzp306dOH4OBgZs6cSfXq1e2qfTo5JGE/IfBWIGGRYSmasAf/NZj9ofsp51GO+e3np9h1hUhJ29/cjquTKyO3juTY9WM2vdZruV4jo0vGFEnYu4N2U6dgnRT/47/k5BLqz6jPw5iHNCrSiD199pDdLXuKxmCvoqKi2LVrF+PHj+f27dtMnDiRM2fOMHjwYLJkyWJ0eC9NEvYTdl3ZBUCdAnVS5HoLTixg3IFxZE6fmX199zncHZ8QyZXdPTsLOiyIXy96ZkObrlvtZHKiZv6a7AraZbNrAFwNv8qlsEvUym/7znSJzT46mw6LOhBrjqV92fas67bO4VcIs4bEiTpLlixs2rSJ7du34+vra8jc9tbm+J/AynYH7yane06KZy/+/INf0dnbZ+m+rDsmZWJn751kcMlg82sKYSS/Un50Ld+VO4/u0HqebdtZ6xSow/Ebx7kfdd9m19gTHD9HQkrWyE07NI2ey3ui0fSt3JcF7Rek+aGfsbGx7N27l/Hjx5MpUyZ2797NokWLqFSpktGhWZUk7CfsDtpN7QK1bf6kGxUbRc1pNYk1xzK51WRey/2aTa8nhL2Y3XY2+TLlY825Ncw6Ostm16ldoDZmbWZf8D6bXWNP0B5cnFyonKeyza6R2KQDk+i7qi8Ab1V6i8mvT07Tk6ForTlz5gzTpk0jJiaGnTt3smTJEsqWLWt0aDaRdv+lk3Ar4hZnbp+hdn7b3y03mtmIO4/u0KNCD/pU6WPz6wlhL0wmE9vf3I6TcqLvyr7ceHDDJtep4VkDhbJpO/bu4N1Uy1eN9M7pbXaNBH8c/oMBfw0AoPtr3ZniNyVNN6GFhYWxaNEi9u7dy9SpU9m4cSPly9t0ig7DScJOZE9QylRvfbX1K3YH76ZkjpLMbDPTptcSwh4Vy16M0U1GE2OOodGsRja5RhbXLLyW+zWbtWNHxUZxMPRgirRfLzm5hL4r45+sO5TtwIw2M9Lsk7XZbObAgQNMnz6drl27EhgYSIsWLYwOK0WkzX/xp9gdtJt0pnRUy1fNdte4spuvtn2Fq7Mre/rsSdN3yCJt+6D2B1TNW5WAmwGM3DLSJteonb82e4P3EmeOs3rZh68dJiouyuY3+BvOb6Dzks5oNE2KNmHuG3NxMtl2GUd7df/+febPn09oaCh79uzhs88+I126tNN+Lwk7kV1Bu6iSt4rNFvwIjwqn2ZxmaDSrOq+SIRgizdvcczOuTq58vf1rAm4EWL38OgXrEB4dTsBN65edUCNnyyfsfcH78JvvR5w5jkp5KrGs07I028Hs7NmzTJ8+nc6dO7N//367WIwjpUnCtoiOi8Y/1N+md8v1ptfjYcxDhtUcRpNiTWx2HSEcRWbXzMx5Y0780+PsJpjNZquWn/D7nDBc05p2B++mcNbC5M2U1+plA1y4e4EWf7YgOi6aglkKsr77ejK6ZLTJteyZ1podO3awYcMGli1bxldffYWTU9qsYZCEbXHk2hEiYyNtlrA/2fgJR68fpWLuioxpPsYm1xDCEbUr245WJVpx7cE1+q/ub9Wyi2QtQp6MedgdbN2OZ1prdgftttnT9d1Hd/GZ40NYZBiZ02dmY8+N5MqQyybXsmfR0dGsWLGCO3fucOTIERo0aGB0SIaShG2R0JPUFgl7X/A+Ru8ajbuzO9vf3G718oVwdEs6LiFz+sxMPTzVqsOwlFLULlDb6k/YQfeDCA0Ptcnfi+i4aN5Y8Abn7pxDoVjVZVWKzAthbx49esT8+fMpXrw4u3fvJm9e29RkOBJJ2BZ7gvdQMEtB8mXKZ9VyI2MiH7dbr+i8gsyuma1avhCpgYuzCys6rwCgxZ8trDoLWp0CdbgYdpGr4VetVqat2q+11gxYPYCtl7ei0Uz1m2rIMr9GCw8PZ+7cubRo0YIFCxbg6iqzuIEk7Mf2Be+jhmcNq5frM9eH+1H36V+1v7RbC/EM3oW9H8+C1nVJV6uVm/AUbM3x2LuDduOezp0KuStYrUyA3/f/zvQj0wH4sNaHvFnpTauW7wjCw8P5888/6dOnD7/99luqmFLUWuQnAVx/cJ3L9y5bPWGP3TeWbZe3UTRbUSa0nGDVsoVIjWa3nU1O95wsOrmITRc2WaXMKnmrkN4pvVUT9p7gPVTPV92qPba3XtrK0PVDUShaFG/BqCajrFa2o3j48CHz5s2jf//+jBw5Uoa9PkESNrAvJL7NrEZ+6yXsi3cvMnT9UNKZ0rGz9075jydEMphMJtZ2WwvAGwvfsErVuIuTC1XzVX38e/6qImMjOXLtiFWrwy+HXabdwnYAFMlWhLnt0t5Y66ioKBYuXEjPnj358ssvjQ7HLknCJr463NnkTJW8VaxSntlspsGMBsTpOKa8PsVmwz6ESI2q5atGn8p9uB91n86LOlulzBqeNTh49SDRcdGvXNbhq4eJMcdY7Qb/Ucwj2ixow73Ie6RzSsfyTsvJ6prVKmU7iri4OJYvX463tzffffed0eHYLUnYxD9hV8hdAfd07lYpb8DqAQTdD6Jp0ab0qtTLKmUKkZZMbjUZD3cPlgQusUrVeM38NYmMjbTKOtyPa+Ss1IQ2ZN0Qjlw7QpyO4w+/P9LkQkCbN28mT548TJ06VWojnyHNJ+w4cxz7Q/Zb7Zdvy8UtTDk8hczpM7O6y2qrlClEWmMymVjTbQ1gnarxmvlrArA3eO8rx7YvZB8FMhewSs3ZnGNzmHxoMgBDagyhy2tdXrlMR3PkyBFCQ0NZsmQJzs7ORodj19J8wg68FUh4dLhVEnZkbCR+8/0AWNt1LS7OLq9cphBpVbV81ehdqbdVqsYLZC5A3ox5rdKOvS94n1Wqw0/dPEW/Vf1wUk7U8KzB902/f+UyHc3169fZsmULq1evJlu2bEaHY/fSfMK2Zocz3zm+PIh+wODqg6ldMOUWtBcitZr6+lRyuudkSeAStl96+UmHlFLUzF/zlZ+wbz68ycWwi698g/8w+iHtF7UnxhxDRpeMLOywMM3NER4dHc3y5cv59ddfU+361dYmCTt4H1lds1IyR8lXKmfaoWlsvbyVwlkKM7bFWCtFJ0TaZjKZWNl5JQBtF7Z9pbnGa3jW4Nydc9yKuPXSZVir/XrIuiGcvHmSWHMss9vOpmCWgq9UniPaunUrderUoVcv6eeTXJKwQ/bh5en1SmvLXn9wnXf+egcn5cTWN7daLzghBLUK1KJL+S7ceXSHt1a+9dLlJLRjv8rUp/uC9+GknKiar+pLl7H45GKmHp4KxE+O8nqp11+6LEd18eJFzp8/z+TJk40OxaGk6YT9MPohx28cf+W75YYzGxJjjuHHZj9SKGshK0UnhEgwq+0ssqTPwsyjMzkQeuClyqiWrxomZXqlavF9Ift4LfdrLz2iJOheEH1W9sFJOVEtXzW+a5z2hjDFxMSwfv16Jk+eLO3WL8imCVsp5aOUOq2UOqeUGp7E++mVUgss7+9TShVO9N4nlv2nlVLNE+2/pJQ6rpQ6opR6ud9ci4NXD2LW5ldK2F9s/oJTt07hlc+LITWHvEo4QoincDY5s6TjEgBa/dnqparGM7hkoELuCuwNebmEbdbmVxpREmeOo9vSbjyMfoirsyvz281Pc+3WAHv27MHLyws/Pz+jQ3E4NkvYSiknYBzgC5QFuiilnuxZ0Ae4q7UuDvwMjLacWxboDJQDfIDxlvISNNRaV9JaV3uVGBPutL08vV7q/OPXj/PfHf/F1dmVDT02vEooQojnaFy0MX4l/bj+8DpD1w99qTJqetZkf8h+zPrFE/7pW6e5F3XvpRP2qJ2j2HFlB3E6jomtJlIse7GXKseRhYWFceDAAcaOlX4+L8OWT9hewDmt9QWtdTQwH2j9xDGtgZmW14uBxip+1HxrYL7WOkprfRE4ZynPqvaF7KNYtmJ4ZPB44XPjzHE0md0EjWbeG/NkFS4hUsCiDovIkC4DY/eP5eztsy98fs38NbkfdZ/AW4EvfO6rjCg5dPUQX26Nn26za/mudK/Q/YXLSA22bdvGe++9R8GCaa+TnTXYMmF7AkGJtoMt+5I8RmsdC9wDcjznXA38rZQ6qJTq97SLK6X6KaUOKKUO3Lx5M8ljXmU8ZY9lPbjx8AZtSrWhTZk2L1WGEOLFuDi7MLPNTDQanzk+L3x+wu/7y7Rj7wveRyaXTJTKUeqFzouMjaTb0m4AFMxckAmt0uZCQKGhoQQFBfGf//zH6FAcliN2Oqurta5CfFX7IKVU/aQO0lpP1lpX01pX8/D49xN0aHgoIeEheOV78Qf3v87+xbwT88jmmo0F7Re88PlCiJfXrmw76hWsx4WwC3y7/dsXOrdkjpJkdc36cgk7ZB/VPau/8KIcn236jMBbgZi1mXnt55E5fdqsjdu9ezcjRowgY8aMRofisGyZsEOAAom281v2JXmMUsoZyALcfta5WuuE7zeAZbxkVfn+kP3Ai7dfhz0Ko+OijgCs6bpGZjMTwgCru6zGxcmFkVtHEno/NNnnmZSJGp412BO854WuFxETwbHrx164/Xrrpa38vPdnAD6t9+njtbnTmtDQUG7cuMHbb79tdCgOzZYJ2x8ooZQqopRyIb4T2conjlkJJIyabw9s1lpry/7Oll7kRYASwH6lVAalVCYApVQGoBlw4qWCC/HH2eRMpTyVkn2O1prmc5sTERPBwGoDqVmg5stcWgjxijK7ZuY3n9+I03H4/un7QufW8KzByZsneRD9INnnHL56mDgd90IJOzwqnB7LeqCUolLuSnzZIO0uGblv3z6GDx+Oq6ur0aE4NJslbEub9GBgPXAKWKi1DlBKfa2USujPPw3IoZQ6BwwDhlvODQAWAieBdcAgrXUckBvYqZQ6CuwH/tJar3uZ+PxD/Smfqzxu6dySfc6Pu39kf8h+CmQuwG++v73MZYUQVtK/Wn9ey/Uax64fY/LB5E/A4eXphVmbORh6MNnn+If6Pz43uT7e+DHB94NxNjkzr/28NDmEC+DOnTtcvnxZnq6twKZt2FrrNVrrklrrYlrr/1r2jdBar7S8jtRad9BaF9dae2mtLyQ697+W80pprdda9l3QWle0fJVLKPMl4uJA6IEXar8+fv04wzcNx6RMrO++Ps0tLi+EPVrXbR1Oyon31r6X7CfmhKSb0CyWHPtD9pM/c/5kr9C1+eJmJh6YCMCYZmMonbN0sq+V2hw8eJC+fftK27UVOGKns1d2/u557kbepbpn9WQdHxETge9cX8zazIj6IyjjUcbGEQohkiNf5nx8Wu9TouKi8JuXvIk4PDJ4UCRrEfaHJj9h+4f6Uz1f8v5ePIh+QK/lvVAovAt5M7D6wGRfJ7WJjo7m2LFjDB482OhQUoU0mbAT7qyT+wvYb1U/QsJDKOdRjs/rf27L0IQQL+jrhl9TMEtBtlzawurTyVuD3svTK9lP2Hce3eHcnXPJ/nvxn43/Ifh+MG7p3JjZduYrrVPg6E6ePEmNGjUoVEimbLaGNPk/yT/EHzdnN8rlKvfcYxcGLGTu8bk4KSeWdloqVeFC2KE1XdegUHRd2pVYc+xzj/fy9OLKvStce3DtuccmzF2enPbrbZe2Md5/PADjWoxLk6twJXby5Eneeecdo8NINdJmwg71p3LeyjibnJ953KWwS/Re0RuAUY1HvfISnEII2yiXqxxvVX6L8Oj4ntnPk9DbOzlP2f4h8R3OnrdC16OYR/Rc3hMA3+K+9KqYtpeNDAsL4/r167Rs2dLoUFKNNJewY82xHLp66LkdzmLNsXRY2IGImAgq56nM0FovN3exECJlTG41mWyu2Zh/Yv5zV/SqnLcyTsopWQl7f+h+SuUoRVbXrM887sutX3Ll3hUyuWTij9Z/ED/LctoVEBDAG2+8Qfr06Y0OJdVIcwk74EYAj2IfPbfD2ZdbvuTA1QM4K2fmtZsnVeFC2DmTycTijosBntsBzT2dO6/lfu25CVtrzf6Q/c/9e3Ho6iHG7BkDwKRWk8iTMc8LRJ46nTt3jq5duxodRqqS5hJ2wnjKZ3Ug2XllJ/+38/8A+K7xd5TK+WJzBwshjNGoSCN8i/ty9cFVPt7w8TOP9crnhX+o/zNX7goJD+Hag2vPrJGLiYuh29JumLWZFiVa0Ll855eOP7W4d+8et2/fxtvb2+hQUpW0l7BD/MnqmpXi2Ysn+X54VDjdlnZDKUXVvFUZVmtYCkcohHgVSzstxc3ZjTF7xnA57PJTj6uRvwZhkWHPXPUrof36WU/YP+7+kcBbgWR0ycg0v2lpvioc4MyZM/j4+ODs/Ox+QuLFpL2EbRlP+bRfqmHrh3Hl3hVMysTMNjOlKlwIB+Pq7MrkVpMxazO+c58+bWlyJlDxD332FMbn75xnxNYRQHwbulSFx7ty5QqtWz+5mrJ4VWkqYT+KecSx68eeWh2++sxqph6eCsDIBiOTNexLCGF/ulfsTtW8VTl16xS/7/89yWPK5CxDhnQZnpmw94fsp0LuCrg6/3sObK01PZf3JNYcS/NizaUq3CIuLo7z58/TtGlTo0NJddJUwj5y7QhxOi7J6q2bD2/SZ2UfnE3OVMhdgY/rPLv9Swhh39Z0XYOTcuKDvz/gfuT9f73vZHKiWr5qT53xzKzNHAg98NQb/DnH57A7aDduzm5Mbz1dqsItrl69SoECBUhqWWPxatJUwn5Wh7P31r3HrYhbaK2Z2WZmmp2oX4jUIlfGXIz0Hkl0XDR+85PuNV7DswZHrh0hKjbqX++dvX2We1H3kpww5XbEbd5ZHT8hyPiW45M9x3hacPnyZRo1amR0GKlSmkvYeTPmxTOz5z/2rzm7hvkn5mPWZobXHf5CS24KIezX5/U/p1CWQmy7vI2Vp59c3Te+HTs6Lpoj1478671n3eAP+GsAD2MeUrdA3TQ/QcqTbty4Qf369Y0OI1VKUwn7QOiBf1WHP4h+wIDVA3A2OVM6R2m+qP+FQdEJIWxhTbf4aUu7L+3+r2lLE56eE5JzYv4h/rinc//XYj/bLm1j8cnFuDi5MK/9PKkKf0JQUBA1aiR/3XCRfGkmYd+Pus/pW6eplrfaP/aP2DKCoPtBxJpjmd5mOumdZVYeIVKTsh5l/zdt6dJ/TluaP3N+cmfInXTCDvWnSt4q/5jCODoumi5LugDxy2bmz5zftsE7mAcPHhAbG0vhwoWNDiVVSjMJ+9DVQ2g01fL9L2H7h/jz675fARhSYwg189c0KjwhhA1NbjWZ7K7ZmR/wz2lLlVJU96z+eLx1glhzLIevHf5XdfiILSO4+uAqFXJVYFD1QSkSuyO5fv06ZcuWlVoHG0kzCTvhlzQhYceaY+m7qi8KRaEshfi20bdGhieEsCGTycTCjguBf09b6pXPi8BbgdyP+l9P8oAbAUTGRv7jBv/c7XP8sPsHTMrEkk5LJCkl4ebNm1SsWNHoMFKtNJWwC2UphEeG+KEGkw5M4tj1Y8TpOKb5TSODSwaDIxRC2FLjIo2TnLa0umd1NJqDoQcf73uyw5nWmvaL2mPWZj6r+9lTZ0pM627fvk358uWNDiPVSlMJO+Fu+VbELT7d/CkAfSr1oXHRxkaGJoRIIUs6LsHV2fUf05YmJOXEE6gcCD3wjymMpx2extHrRymYpSBfen+Z8oE7iIcPH1K8uNzM2EqaSNix5ljO3z3/OGF/uulT7kfdx8Pdgx+b/2hwdEKIlOKWzo0prab8Y9rSHO45KJqt6D86nvmH+lMtXzWUUtyPus97a98DYHmn5TJd8XMUKVLE6BBSrTSRsCNiIoD4O+nDVw8z9VD89KNT/aY+d41bIUTqktS0pdXzVX+csGN0DMeuH3s8oqTX8l48in3EW5XeonLeyobFbe+01gAUKFDA4EhSrzSVsCvnqUyflX3QaNqWbotfqWevmSuESJ3WdF2Ds8mZD9Z/QFhkGF6eXly5d4V7cfe4En2FWHMs1T2rs+vKLpYHLiera1bGtxxvdNh27e7duwC4u7sbHEnqlSYS9sOYhxTPXpw1Z9dw+NphMqTLwMRWE40OSwhhkFwZczGywUiizdH4zfN73I59Meoil6IvAVA1b1XaLWwHwLx282SOhue4efOm0SGkemkjYUc/pEqeKry77l0AJrScQK4MuQyOSghhpM/qf0aRrEXYcWUHoeGhmJSJi9EXuRh1kVwZcjFu/ziuP7xO06JN8SnuY3S4du/OnTtGh5DqpYmEHRMXw/WH1wmLDKOGZw26V+hudEhCCDvwV9e/UCj6rupLWY+yXIy6yMXoi7yW6zXG7B1Deqf0LO6w2OgwHYIkbNtLEwkbYMflHTgrZxZ1WCQTHgghACjjUYZ+VfrxIPoBD6IfcC7qHFdjrhJwMwCzNvOrz69kds1sdJgOI1OmTEaHkKrZNGErpXyUUqeVUueUUsOTeD+9UmqB5f19SqnCid77xLL/tFKqeXLLfBozZj6v/zkFskgPRiHE/4xvOZ7sbtm5FHaJR/oRGs21B9co61GW/tX6Gx2eQ8mYMaPRIaRqNkvYSiknYBzgC5QFuiilyj5xWB/grta6OPAzMNpyblmgM1AO8AHGK6WckllmkvJlyscXDWQlLiHEP5lMJpZ0XPKPfQrFX13+MigixyVP2LZlyydsL+Cc1vqC1joamA+0fuKY1sBMy+vFQGMVX1/dGpivtY7SWl8EzlnKS06ZSXorw1uYlImYmBi8vb2ZM2cOABEREXh7e7NgwQIA7t27h7e3N0uXLgXg1q1beHt7s2rVKgCuXbuGt7c369atA+KXkvP29mbjxo0AXLhwAW9vb7Zt2wbA6dOn8fb2Zvfu3QCcOHECb29v/P3jx3weOXIEb29vjhw5AoC/vz/e3t6cOHECgN27d+Pt7c3p06cB2LZtG97e3ly4cAGAjRs34u3tTVBQEADr1q3D29uba9euAbBq1Sq8vb25desWAEuXLsXb25t79+4BsGDBAry9vYmIiB/6NmfOHLy9vYmJiQFgxowZeHt7P/45TpkyhSZNmjzeHj9+PL6+vo+3f/31V/z8/jdc7scff6Rdu3aPt0eNGkXnzp0fb3/zzTd07/6/PgUjRoygd+/ej7c/+eQT+vXr93j7ww8/ZNCg/y26MGTIEIYMGfJ4e9CgQXz44YePt/v168cnn3zyeLt3796MGDHi8Xb37t355ptvHm937tyZUaNGPd5u164dP/74v8l1/Pz8+PXXXx9v+/r6Mn78/4b7NGnShClTpjze9vb2ZsaMGQBW/793+/ZtRo0aJf/3LF7l/553YW+Km/83Q9d7Nd5j0veT5P+e5f9ecsmQLttSCYPdrV6wUu0BH611X8t2D6CG1npwomNOWI4JtmyfB2oAI4G9Wus5lv3TgLWW055ZZqKy+wEJv23lgRNW/5DiReUEbhkdRCojP1Prk5/pv5XSWv/j8VkpdRO4nGhX1ZQNKVU5AURZXhfSWnskdZBzUjtTA631ZGAygFLqgNa62nNOETYm/w7WJz9T65Of6b8ppQ48ue9pSUXYji2rxEOAxD288lv2JXmMUsoZyALcfsa5ySlTCCGESHVsmbD9gRJKqSJKKRfiO5GtfOKYlUAvy+v2wGYdX0e/Euhs6UVeBCgB7E9mmUIIIUSqY7Mqca11rFJqMLAecAL+0FoHKKW+Bg5orVcC04DZSqlzwB3iEzCW4xYCJ4FYYJDWOg4gqTKTEc5kK3888XLk38H65GdqffIz/Tf5mdgBm3U6E0IIIYT1pJmZzoQQQghHJglbCCGEcACSsIVNKaUePLH9plLqd6PiSS2UUnFKqSNKqRNKqUVKKZmxQlidUkorpcYk2v5QKTXSwJDSNEnYQjimR1rrSlrr8kA0MMDogESqFAW8oZTKaXQgIpUn7ERPIQlf8kdNpEY7gOLPPUo8k/y9SFIs8T3EhxpxcaWUt+UpP+ErTil111KzNNOyGFSSyy8qpXIppb5XSgUopR4qpcKVUoeVUiOUUkkuwaaUKqqUmqyUClRKRViudcpyrYa2/bTPl2pnOrN4pLWuZHQQaZybUupIou3syNh5q7FMOOQLrDM6llRA/l4kbRxwTCn1vYExzAPWAArIBJQC2gA9gY1KqQ5a67CEg5VStYBVQGZgLvAb8UOBGxI/9XVvpVRzrfWZROdUA7YBMcAsIABwI34ekGZAOLDFhp/xuVJ7whbG+8cfQaXUm4BM+/jqEt8I7SB+TgMhrE5rfV8pNQt4D3hkUBiHEtaWSKCUGgZ8DwwjPqH7WvbnAVYQn9/qaK39E502XinVAlgOrFRKVdZaJ3ymLwF3oJLW+uiTAVjKNVSqrhIXIhVLaMOupLV+17J6nRC28gvxyyFnMDiOx7TWcVrrD4CdgI9Sqq7lrY8AD+DTJ5J1wnlriP88pYj/TAlKALeTStaW865ZMfyXIglbCCHEM2mt7wAL+WeCsxcJtUstLd/bEd8Rc8YzzklYh7Rdon3ngRxKqTesGp0VScIWQgiRHGOIX3rU3hyzfC+plMoEFAJOa60jnnaC1vos8W3SryXa/S3x7ddLlFJnlFJ/KKXeUUqVsVXgL0rasIVNaa0zPrE9g2ff+YpkePLnKoQtJP5/prW+Tnwbr725b/me2fIFcC+Z5+VO2NBa71FKVQU+IL49vLflC6XUDuBNrfUFawX9MuQJWwghhCNLSNL3+V/yzpLM8/6R2LXWx7XWb2qtcwOFiV9NcgdQD1hhWSXSMKk6YctTiBAiueTvhcOqYPl+WmsdDlwBSj1r9j+lVHHih4cdf9oxWuvLWutZQANgF1Ae8LJa1C8hVSdsIYQQqV5CR7i/LN+XAi7Ej9F+mr6Jjn0mHb+k5T7LpufLBGgtkrCFEEI4HKWUk1LqR6AusEZrvcvy1g/AbeD/lFJVkjivOfFjt8+QaP4CpVRTy0RETx7vRvzEKQAnrfspXox0OhNCCGHvqiilulteJ57prBDwN9A14UCtdahSqg3xk6fsUUrNBfYSP9OZN9Ce+Gpzvyd6kv9M/LCulcRXlUcABSxllwRmaa2fWoWeElT8074QQghhX5RS3vxzOlAz8AAIBg4A87TWSU7La5mZ7EPix2cXspx7DlgG/KK1vvfE8c2A1sQ/sXsCWYnvlHYMmA3M0FqbrfPJXo4kbCGEEMIBSBu2EEII4QAkYQshhBAOQBK2EEII4QAkYQshhBAOQBK2EEII4QAkYQshhBAOQBK2EEII4QAkYQshhBAOQBK2EEII4QD+H8vI6vjehHK3AAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfYAAAE1CAYAAAAVl8KmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAB16UlEQVR4nO3ddXgUV9vA4d8TJzjBgwV3Ce7B3d3bUqhAjdK31HjrpU4F+qKlWIEixYK7huDuGjRIsED0fH/MhG+bJpDAZifZnPu6ciU7O+fMM5PdeWbOnDkjSik0TdM0TXMOLlYHoGmapmma/ejErmmapmlORCd2TdM0TXMiOrFrmqZpmhPRiV3TNE3TnIhO7JqmaZrmRJ4psYvIehF50V7BpAQR+VhEpjvbstILEQkQkRCr40gOEckjIhtF5K6IfJ/MsvdEpGhKxeYsRMRTRA6LSD6rY3kW5nocFZFcdqjrfyLy0WPeT/b+SUT+FJGOzxpbShKRiiKy1eo4UoqIFBERJSJu5usn5t0nJnYROSsiD8wdzlURmSIimewVtPZoGzdNwfqViBRPqfqtZK7bffPzeUNE1ohIjwTmaysiO8x5b4jIDBEpYPO+h4h8LyIhZl1nRWT0U4Y1GLgOZFFKvZ1ALFNE5POECiqlMimlTtvMF2nGE/fzr3WLV3fcTuCezXqMsHlfROQdETlhfq/Pi8hXIuKZQF0eInLkcQdW5oGXEpEF8aZXMqevf1y8NvN3F5GtIhKexDKDgY1KqctJqf9ZichQEdkpIhEiMiXee7VEZJWI3BSRUBH5y/aAQ0SyicgfInLN/Pk47j2lVAQwGRjBM1JKvayU+sxc5jMfEItIRaASsNB8/X68z+IDEYkVkZxJqKt+vLL3zM9HlyTGEr9sjIj8AqCU2g+EiUi7Z1hdp5LUM/Z2SqlMgD9QDfgw5ULS4os7UrNw+a5WLj8JKpmfz1LAFOBXEflv3Jsi0hWYCYwGcgLlgAhgs4hkN2d7D+OzXQPIDAQAu58ynsLAYWWf0Z++MZN93M/sJJbLZm6TXsBIEWlpTv8ZIyn2x1jPVkATYE4CdbwDhCZhWaFAbRHxsZk2ADiexFgBbmL8f0Ylcf6XgWnJqP9ZXQI+x0jC8WUHxgNFMP73d4Hfbd7/EfA2368B9BOR523enwkMSOjgymIvATPiPsdKqS9tP4vA18B6pdT1J1WklNoUr2xb4B6wPCmBxCubF3gA/GUzywwz3lTJPKB23KVvpdRjf4CzQFOb198CS8y/1wOfAVswPswrgZw287YHDgFh5rxl4tU7HNgP3AZmA1427w8CTmJ84RcB+W3eUxhf7BNm3WMASST+j4G5Zv13MXbWlWzeHwGcMt87DHSyee85YDPwHXALOAO0snnfD9hgll0F/ApMTySOnMASM96bwCaMA6tpQCzGB/Ue8B+MHYACBgLngY0YiSYksf8N4Aq8b7Muu4CCZlkF3Dfr7xG3XvHqUkBx8+8pwG9AoFmuKZAfmIexEz8DvP6Yz0wbYA9wB7gAfGzzXty6DTDX7Trwgc37Gczl3zL/H+/EX+/E4raZ1hV4CPgAApwD/hNvHhfgIPCp+XoJ8OaTvg825esAwRif3WCgjs22iwIize3dNIGyU4DPn7Q+ic1nxh73ub2BkZRzxNu+bjbzB2N810oAMUCNePUVxDjQaRzvs30EI/E/bvsHACHA/4AhNp/Fi8BIjB3/Y7dZvPpetC2TyDILYXxfbNdxCjAWWGZu9y0YCWC0+Vk6ClSJ9915z/yM3cJIxF6PW65Z7nNgyhPm8Qfu2ry+DlS3ef0+sClemRNAwwTq8jLXNaf5+gMgGqM1CIz972jbzwuQ0SwTa26Lexjf34/Nz8pUjH3EIaDaY9bjNFAvkffEfH9AUr8z8cr/Dvz+lGUHmMsWm2m+5jp7JlLmObPMXYz9Vx9z+sfY7LOJ9/3ByFtfATsw9mcLMb9r5vu1gK0Y+/V9QIDNe+uBL8zP4gOgOMZJxSqMHHAVeD+532mz3hcft42SdQQhIgWB1hg77Ti9geeB3IAHxg4EESkJ/Am8CeTCSBKLRcTDpmx3oCXGTqQixsZHRBqbG7M7kA9jxzwrXjhtgepmue5Ai8eE3gHj6C4HxtHx3yLibr53CqgPZAU+AabLP6/b1QSOYSTmb4BJIiLmezMxEmhOjC/YgMfE8DbGDjAXkAfjy62UUv0wElw7ZRyRfmNTpiFQ5gnrFmcYxtlZayAL8AIQrpRqYL5fSSXvjK83xocyM8YHdzHGB9cX4wzvTRFJLK77GGeE2TCS/Cvy7+t09TDOsJtgnFGWMaf/Fyhm/rTg8ds0MQsBN4yzo1IYicD26B6lVCzGgUozc9J2YJiIvCoiFWz+x/8iIjmApRhnvz7AD8BSEfFRSj2HcfYQd6a9+inif5LXgI4Yn4/8GIlpTAJxiojUxdiZ7MHY1iFKqR228ymlLmCsfzObyb9gfEYfJDGmqRj/czD+bwcxznLjYkl0myWxflsVgNNKqeh407tjtCbmxDhQ2YZxIJ8T4+D+h3jz9zFjLQaUxH4tkQ0wkqYtifd3+XjvH8Fo9v4HpdRDjIOghuakhhj7w7o2rzfEK3Mf44Dskvr/M924/0V7jH1pNowTpl8TWgERyYixXz6W4Boa+8zcGN+hZDHr7gr8kdyypgHAVGVmOQCl1EWMA+pSiSzvZ4yTsswYB5h7k7G8/hj703wYB1U/m/X6YnymP8fILcOBefLP/hL9MFrIMmMk8tUYrRT5MRL9GnO+JH2nkyqpif1vEQnDOHvdAHxp897vSqnjSqkHGEcZlc3pPYClSqlVSqkojLPeDBgbNc7PSqlLSqmbGIkjrmwfYLJSarcyrkG9h9HUV8Sm7CilVJhS6jywzqZsQnYppeaacfyAcRRcC0Ap9ZcZQ6yZ9E5gJIQ455RSE5RSMRgfxHxAHhEphHFg8ZFSKkIptdFch8REmWULK6WilNE09aSm2o+VUvfNbfskLwIfKqWOKcM+pdSNJJRLzEKl1BYzAVYAcimlPlVKRSrjGvAEoGdCBZVS65VSB8xtuh/jAK9hvNk+UUo9UErtwzhgiNupdQe+UErdNBPOz8kN3Pw/X8f4ssVd/0voWuxlm/e/wmha7APsBC6KSGIHFW2AE0qpaUqpaKXUnxhnhClxjW+4iISZP3FNni9jtHKEmN+Pj4Gu8S7ZXMc4K5gIjFBKrcFY18SuST/aFiLSCXBVSi1IZN5/UUptBXKISCmMHeHUeLPYc5tlwzjzim+BUmqXmQwXAA+VUlPN7+5soEq8+X9VSl0w9z9fYBwYPxPzuvRIjJamOMuBESKSWYy+Li9gNM3bumuuV0I2AA3N/29FjO9EQxHxwtgHbUxGiJuVUoHmNplGAgcTprhYEtrOYCTXuUqpe8lYdpzOGJ/PDU+aMT4RKYyxL0nooOBx2zAWKC8iGZRSl5VS8Q+8HmeaUuqgecD0EdDdvDzZFwg0t2esUmoVxr6jtU3ZKUqpQ+ZBaFvgilLqe6XUQ6XUXaVUkDlfUr7TSZbUxN5RKZVNKVVYKfVqvERzxebvcCCuY11+jCNL4NEZ0gWMM77klr2H0TyRlLIJuRAvjhBzGYhIfxHZG7fzxDiStu0McsWmbLj5Zyaz/C3znx3nHIn7FuPSwkoROS02HZqSEncSFMRofbAX22UXBvLbJJgwjLO5PAkVFJGaIrLO7Eh0G+NDG7+DzeP+97bLftw2TZDZGpMLI7HFJcOEek/ni3tfKRWjlBqjlKqLsXP4Aphs05Jg6x+fT5s4fROY91l9Z373siml4rZhYWCBzf/iCEYTu+3/I6dSKrtSqoxSKu7g6DoJbwfM6dfNs5tvgNefItZpwFCgEUZitWXPbXYL4wwovqs2fz9I4HX8fUT8z1ncPmGZTSetPkkNykzay4A3lFKbbN563Vz+CYzWpD8x9kG2MmM05yZkA8YlD3/gAEZTbkOMk5OTyTyAj/+980okecTF8q/tLCLeQDfseMadDP0wDk7OJPBegtvQ3Ef3wNgPXRaRpSJSOhnLjP85ccfYnxUGusXbL9bjn98x27KP20cn5TudZCl5Mf8SRrCA0SyIsWIXn6JsRozmu6SUTUhBm7pcgALAJfPobwLGzshHKZUNowkx0WZYG5eB7GZscQolNrN5dPa2UqooRnPYMBFpEvd2YsVs/r6PzVG+ecRo2+RzAaNJMSni15X3Ccu+AJyxSTDZlFKZlVKtEygHxiWKRUBBpVRWjOuvSdmmYGzXgjavE92mj9EBo8lsB0ZTYgjGjugR83PQhf9vCnvEbEkYg5FAyiZQ/z8+nzZxPu3nM7kuYDQr2v4/vJTRHPk4a4GCImLbIhV3ia0WxrYogXFNb5OIXAHmA/lE5Eq8FrOETANexTiLCY/3nj232X7Azw6dSuN/zi4BKKVaqf9vwp6RlIrMfclq4DOl1D869ZmtT32UUnmVUuUw9rs74lVRBqPlKiFbMZqYOwEblFKHzXhbk/hZ79MkTduY72MkoZIJvN0J46B5fXLrNT9rAfy7RSep+pPAAYXZLO5BIpcOlFIrlFLNMJLuUYz9PsTbF2L0y4gv/uckrkXwAsbZvO33MKNSyrYDaPz9aGK3sj7tdzpBKZnY5wBtRKSJeQb1NsZ1r6Tcb/gn8LyIVDZ7in4JBCmlzj5lLFVFpLO5I3jTjGM7RicThdnz1+ypGv/aV4KUUucwml0+EeO2oHo8pllRjNutipsHOLcxjsZizbevkvg/PM5xjKPrNub2/BCw7UU7EfhMREqY11Yr2ly/jF//PqCcuX29MJp9HmcHcFdE3hWRDCLiKiLlRaR6IvNnBm4qpR6aSaT3E+q3NQd4T0Syi3E72mtJLSgiOcwzrDHA10qpG+ZZwXDgQxHpLSJe5oHMRIy+CD+aZd8U4xahDCLiZjbDZ+af/UniBAIlzfrcxLgFrSxGB7ykcjVjifvxeHKRR/4HfGEmE0Qkl4h0eFIhpdRxs+wMMW7RchWRchjXSVcroz/AQYwdWWXz50WMz09lntCCZJ5FNcTo4BXfY7eZGYsXRt8IF3ObuCdQD0qpEIzWrxoJvZ8MQ0SkgBjX/z/AaK5PkBmzF0bHwLj/Xdx9xb4YB02/KqX+l0DZYiLiY65jK4xrrp/bvO+Lcdloe0LLNg+SdgFD+P9EvhXjDDSxxH4V8BGRrImv/hMF8u9LaJDIGbcY98mvf0Kd/YCtSql/nLma373HHoyISB2MFp6/Eni7IbDWbMaOXy6PiHQwT8IiMDoTxu179wINRKSQua3eS6DuviJS1myp+BTjEkQMMB1oJyIt4j6/5noUSKAOMD7r+cx9jacYl2Zqmu891Xc6MSmW2JVSxzCuQfyCcXTTDqODWGQSyq7GuJYxD+MMrhiJXM9NooUYTTG3MD5YnZVxnfsw8D1GJ5urGNeStySj3t4YnetuYnT6etxRaAmMI/p75vLGKqXWme99hZF4wkRkeEKFlVK3Mc6GJmKc5dznn815P2AkxZUYvTcnYfRpACNx/2HW393cwX9qxnMCo+9EoswPcVuMnfsZjP/nRIwOhwl5FfhURO5iXG9M6FaqxHyC0dx1xlyXpNzStE9E7mHs7F8E3lJKjbSJfzbG//0tjEs6hzG2TV2bZsxwjM/CFXP9hgBdlHlPuS2zTFuMg9UbGHcytFVJuO3HxgiM5tm4n7XJKPsTRovISnMbb8f4HCbFUIz/3XT+/3aj9RitF5jXv6/E/WB8tmPN1zFPqlwptVn9f0ct2+lP2mb9MLbDbxgdsx7w/2dVCRlnlnkWMzE+Y6cxzk4THFvA9KEZ0wiM/doD/r+z3YsYB84fi8291jZlq2I0od/F+K73iXeNtzfwR0JJycYGjCbgHTavM5PI9XWl1FGME6TT5vc+/2PqTsx4oI95MgI8OghpTML7uoI8ef+Z4Bm3WfZJJ30DgPlKqYSu+/fBSI4JccHoXHwJ4/PcEHgFwLwuPhujFWgXCR+cT8O44+AKRv+s182yFzBaB9/HODm8gNG3IsG8asbdDCMXXsHY9zYy336W7/S/yNNd5tA0TbOO2ZK3B2iinmKQGhE5i3HLUErctZCcODwxWtAaKKWuWRlLQkRkJjBHKfV3Eubdi/H/SHanXRGZCPyllFrxFGUrAuOUUrWTWzYJda/HuB1uor3rTkmWDnyiaZr2NMyz24T6P6Qp5nokpyOXQymlknwZTSlV+RmW89RDkyvjzhu7J/W0TD8ERtM0TdOciG6K1zRN0zQnos/YNU3TNM2J6MSuaZqmaU5EJ3ZN0zRNcyI6sWuapmmaE9GJXdM0TdOciE7smqZpmuZEdGLXNE3TNCeiE7umaZqmORGd2DVN0zTNiejErmmapmlORCd2TdM0TXMiDkvsItJSRI6JyEkRGZHA+54iMtt8P0hEipjTa4jIXvNnn4h0silzVkQOmO/tdNS6aJqmaVpq5ZCHwIiIK3Ac4yHzIUAw0EspddhmnleBikqpl0WkJ9BJKdVDRLyBSKVUtIjkw3h2cX7z9VmgmlLqeoqvhKZpmqalAY46Y68BnFRKnVZKRQKzgA7x5ukA/GH+PRdoIiKilApXSkWb070A/Tg6TdM0TUuEoxK7L3DB5nWIOS3BecxEfhvwARCRmiJyCDgAvGyT6BWwUkR2icjgFIxf0zRN09IEN6sDSAqlVBBQTkTKAH+IyDKl1EOgnlLqoojkBlaJyFGl1Mb45c2kPxggY8aMVUuXLu3Q+LV/unHjBgA+Pj4WR+I89Da1P71NE7dr167rSqlcttNy5sypihQpYlFEzimh7ZwUjkrsF4GCNq8LmNMSmidERNyArMAN2xmUUkdE5B5QHtiplLpoTr8mIgswmvz/ldiVUuOB8QDVqlVTO3fqfnZWmjJlCgDPPfecpXE4E71N7U9v08SJyLn404oUKYLet9pXQts5KRzVFB8MlBARPxHxAHoCi+LNswgYYP7dFVirlFJmGTcAESkMlAbOikhGEclsTs8INAcOOmBdNE3TNC3VcsgZu9mDfSiwAnAFJiulDonIpxhn3ouAScA0ETkJ3MRI/gD1gBEiEgXEAq8qpa6LSFFggYjErcdMpdRyR6yPpmmapqVWDrvGrpQKBALjTRtp8/dDoFsC5aYB0xKYfhqoZP9INU3TNC3t0iPPaZqmaZoT0Yld0zRN05yITuyapmma5kR0Ytc0TdM0J6ITu6ZpmqY5EZ3YNU3TNM2J6MSuaZqmaU5EJ3ZN0zRNcyI6sWuapmmaE9GJXdM0TdOciE7smqZpmuZEdGLXNE3TNCeiE7umaZqmORGd2DVN0zTNiejErmmapmlORCd2TdM0TXMiOrFrmqZpmhPRiV3TNE3TnIhO7JqmaZrmRHRi1zRN0zQnohO7pmmapjkRndg1TdM0zYnoxK5pmqZpTkQndk3TNE1zIjqxa5qmaZoT0Yld0zRN05yIwxK7iLQUkWMiclJERiTwvqeIzDbfDxKRIub0GiKy1/zZJyKdklqnpmmapqU3DknsIuIKjAFaAWWBXiJSNt5sA4FbSqniwI/A1+b0g0A1pVRloCUwTkTcklinpmmapqUrjjpjrwGcVEqdVkpFArOADvHm6QD8Yf49F2giIqKUCldKRZvTvQCVjDo1TdM0LV1xVGL3BS7YvA4xpyU4j5nIbwM+ACJSU0QOAQeAl833k1InZvnBIrJTRHaGhobaYXU0TdM0LXVKE53nlFJBSqlyQHXgPRHxSmb58Uqpakqparly5UqZIDVN0zQtFXBUYr8IFLR5XcCcluA8IuIGZAVu2M6glDoC3APKJ7FOTdM0TUtXHJXYg4ESIuInIh5AT2BRvHkWAQPMv7sCa5VSyizjBiAihYHSwNkk1qlpmqZp6YqbIxailIoWkaHACsAVmKyUOiQinwI7lVKLgEnANBE5CdzESNQA9YARIhIFxAKvKqWuAyRUpyPWR9M0TdNSK4ckdgClVCAQGG/aSJu/HwLdEig3DZiW1Do1TdM0LT1LE53nNE3TNE1LGp3YNU3TNM2J6MSuaZqmaU5EJ3ZN0zRNcyI6sWuapmmaE9GJXdM0TdOciE7smqZpmuZEdGLXNE3TNCeiE7umaZqmORGd2DVN0zTNiejErmmapmlORCd2TdM0TXMiOrFrmqZpmhPRiV3TNE3TnIhO7JqmaZrmRHRi1zRN0zQnohO7pmmapjkRndg1TdM0zYnoxK5pmqZpTkQndk3TNE1zIjqxa5qmaZoT0Yld0zRN05yITuyapmma5kR0Ytc0TdM0J6ITu6ZpmqY5EZ3YNU3TNM2JOCyxi0hLETkmIidFZEQC73uKyGzz/SARKWJObyYiu0TkgPm7sU2Z9Wade82f3I5aH03TNE1LjdwcsRARcQXGAM2AECBYRBYppQ7bzDYQuKWUKi4iPYGvgR7AdaCdUuqSiJQHVgC+NuX6KKV2OmI9NE3TNC21c9QZew3gpFLqtFIqEpgFdIg3TwfgD/PvuUATERGl1B6l1CVz+iEgg4h4OiRqTdM0TUtjHJXYfYELNq9D+OdZ9z/mUUpFA7cBn3jzdAF2K6UibKb9bjbDfyQiktDCRWSwiOwUkZ2hoaHPsh6apmmalqqlmc5zIlIOo3n+JZvJfZRSFYD65k+/hMoqpcYrpaopparlypUr5YPVNE3TNIs4KrFfBAravC5gTktwHhFxA7ICN8zXBYAFQH+l1Km4Akqpi+bvu8BMjCZ/TdM0TUu3HJXYg4ESIuInIh5AT2BRvHkWAQPMv7sCa5VSSkSyAUuBEUqpLXEzi4ibiOQ0/3YH2gIHU3Y1NE3TNC11c0hiN6+ZD8Xo0X4EmKOUOiQin4pIe3O2SYCPiJwEhgFxt8QNBYoDI+Pd1uYJrBCR/cBejDP+CY5YH03TNE1LrRxyuxuAUioQCIw3baTN3w+BbgmU+xz4PJFqq9ozRk3TNO3ZTZw4kZCQED7++GOrQ0mX0kznOU3TNC1t+OSTT/jkk0+sDiPd0old0zRNsytXV1erQ0jXdGLXNE3T7Mrd3d3qENI1ndg1TdM0u/Lw8LA6hHRNJ3ZN0zTNrjJmzGh1COmaTuyapmmaXWXJksXqENI1ndg1TdM0u8qdWz9B20o6sWuapml2VaBAAQCUUhZHkj7pxK5pmqbZVZ48eQC4du2axZGkTzqxa5qmaXYV9wTtDRs2WBxJ+qQTu6ZpmmZ3rq6uzJs3z+ow0iWd2DVN0zS7q1ixIsuWLeP8+fNWh5Lu6MSuaZqm2Z23tzf+/v68++67VoeS7ujErmmapqWIOnXqsHHjRsaNG2d1KOmKTuyapmlaivD09KRz586MGDGCP//80+pw0o0kPY9dRIYlYbb7Sil9WKZpmqY9kjNnTnr27Mkbb7zBkSNH+OSTTx71mtdSRlLP2N8BMgGZH/PzdkoEqGmapqVtefPmpX///syYMYPatWuzb98+q0Nyakk6YwemKaU+fdwMIqJH/dc0TdMSlDlzZvr27cvu3bsJCAigR48efP755+TMmdPq0JxOUs/Yf3jSDEqp/zxjLJqmaZoTc3FxoVq1agwePJj9+/fj5+fHwIEDOXLkiNWhOZWknrHvFZGDwJ/APKVUWMqFpCVF2MMwNp3bxM5LO8nimYU8mfKQN1NeKuSuQJ5MeawOT9M0LVHe3t60aNGCunXrsmvXLurUqUPVqlUZNmwYzZo1w93d3eoQ07SkJnZfoCnQE/hSRLZjJPmFSqkHKRWc9k+RMZH8HPQzfx78kz2X96D49wMW3Fzc6Fq2K6/VeI3aBWrrTiqapqVamTJlomHDhtSpU4cDBw7w+uuvc/PmTbp27Ur//v2pU6cOLi765q3kSlJiV0rFACuAFSLiAbTCSPKjRWSNUqpPCsaoAWtOr2FI4BCO3ThG3YJ1+W/D/9LIrxE1fGsQGRPJlXtXuHT3EouOLWLynsnMOjiLqvmqMrbNWGr41rA6fE3TtES5u7vj7++Pv78/N2/e5NChQ/Ts2ZOYmBh69+5Np06dqFWrFm5uST0XTd+SvZWUUpEichg4AlQFytg9Ku2R2w9v89KSl5h9aDbFshcjsHcgrUq0+sc8Xm5eZPHMQkmfkgQUCeDTRp8yff90vtr8FXUn1+Xrpl/zVq239Nm7pmmpXo4cOahfvz716tXj6tWr7Nq1i7lz53L79m1atGhBp06daNGiBdmzZ7c61FQryW0cIlJQRN4Rkd3AErNse6WUf4pFl87dfHCTptOaMv/IfD4J+ISDrx78V1JPSCaPTLxc7WX2vrSXtiXb8vbKt+kwqwM3H9x0QNSapmnPTkTImzcvjRo14oUXXuCFF17g/v37fPHFFxQoUIDatWvz5ZdfsmvXLmJjY60ON1VJ6gA1WzGus88BBimldqVoVBqh90NpOq0px64fY0GPBbQp2SbZdWTPkJ353efzy45fGL5yOLUm1mLDcxvIlzlfCkSsaZqWcrJmzUr16tWpXr06kZGRnDlzhqVLlzJmzBju379Po0aNaNOmDc2aNaNw4cJWh2uppDbFjwA2KaX+3VtLs7vLdy/TZGoTzoadZXGvxTQr1uyp6xIRXq/5Ov75/Gk5vSXNpjVjw3Mb8PH2sWPEmqZpjuPh4UGpUqUoVaoUALdv3+bUqVOMHTuWt99+mxw5ctC8eXNatmxJo0aNyJYtm7UBO1iSmuKVUhuVUkpESorIGvPWN0Skooh8mJQ6RKSliBwTkZMiMiKB9z1FZLb5fpCIFDGnNxORXSJywPzd2KZMVXP6SRH5WZzgIvKDqAe0nNGSC3cusKzPsmdK6rbqFarHol6LOHnzJC2mt+D2w9t2qVfTNM1qWbNmxd/fnw4dOvDmm2/SvHlzzpw5w4cffkj+/PmpXLky7733HuvWrSMiIsLqcFNccu8jmAC8B0QBKKX2Y/SOfywRcQXGYPSmLwv0EpGy8WYbCNxSShUHfgS+NqdfB9oppSoAA4BpNmV+AwYBJcyflslcn1TnrRVvsf/qfuZ0nUPDIg3tWndjv8bM7zGf/Vf303pma+5H3rdr/ZqmaVZzcXEhf/781K1bl+7duzNs2DAqV67Mtm3bGDRoEDly5KBp06b8+uuvnDp1yupwU0RyE7u3UmpHvGnRSShXAziplDqtlIoEZgEd4s3TAfjD/Hsu0ERERCm1Ryl1yZx+CMhgnt3nA7IopbablwimAh2TuT6pyuyDsxm3axz/qfOfJHWSexqtS7Tmzy5/su3CNl5e+jL66oqmObf0/h13d3fHz8+PRo0a0a9fP1577TWyZ8/O1KlTqV69OkWKFGHIkCEsW7aMhw8fWh2uXST3drfrIlIMjJFRRKQrcDkJ5XyBCzavQ4Caic2jlIoWkduAD8YZe5wuwG6lVISI+Jr12Nbpm9DCRWQwMBigUKFCSQjX8U7ePMmgxYOoXaA2nzf+PEWX1aVsFz4J+ISR60dSv1B9BlcdnKLL0zQt5Sml2H15N3/s+4PAE4GEPQwjPCqcB9EPKJy1MDV8a1DDtwYBRQKomq9qur39NUOGDJQvX57y5csTGxvL1atXOX78OG+88QZXrlyhVatW9O3bl+bNm+Pp6Wl1uE8luYl9CDAeKC0iF4EzgEMGpxGRchjN882TW1YpNR4jbqpVq5bqDl8joiPoMbcHbi5u/NnlT9xdU344xQ8afMDmC5t5fdnrVMtfDf98+q5F7dkduHqA5SeXc/LmSU7cPEHInRBK+pSkpm9NavjWoF6hemT00M+Lsre5h+fy8fqPORR6CA9XD1oWb4lvZl8yumfE082TEzdPEHwxmL8O/wVAKZ9S9K/Un74V+1Ioa+o82XEEFxcX8uXLR758+ahXrx53797lyJEjvP3221y9epW2bdvSv39/mjVrlqZGwEtWYldKnQaamk9yc1FK3U1i0YtAQZvXBcxpCc0TIiJuQFbgBoCIFAAWAP2VUqds5i/whDrThB+3/8juy7tZ0GMBhbM55jYNF3FheqfpVBlXhW5/dWPX4F1k88rmkGVrziVWxRJ4IpAft//I2jNrAcjpnZPiOYpTMU9FDoceJvBEIApFvkz5GN1yNN3Kdku3Z4z2FBEdwfCVw/k1+Fcq5anEb21+o0e5HmTPkPDgLaH3Q1l0bBHT9k/jg7Uf8OHaD2lbsi1DawyladGmuEjaSV4pIXPmzNSoUYMaNWpw584dDh8+zODBg/H09OSjjz6iZ8+eaWIc+yT9F0Wkre1rpdT9+Ek9/jzxBAMlRMTPHJK2J7Ao3jyLMDrHAXQF1po98bMBS4ERSqktNjFcBu6ISC2zN3x/YGFS1ic1uXz3Mp9v/JwOpTrQsXRHhy47V8ZczOk2h/O3z/PiohfT/bU4Lfm2h2ynwm8VaPdnO45dP8aoJqO4Ovwqoe+Esm3gNuZ2n8vhIYe59e4tAnsHki9zPnrM7UHrma05feu01eGnaefCzlH/9/r8Gvwrw2oNI3hQMC9XeznRpA7Gd36g/0DWP7eeM2+c4YP6HxB0MYgW01tQZkwZftj2A6H3Qx24FqlXlixZqFWrFs8//zw1a9bkiy++oHDhwowZMybV7yuTenj2rYhUERH/xH6ALxMrrJSKBoZijDd/BJijlDokIp+KSHtztkmAj4icBIZh3DuPWa44MFJE9po/uc33XgUmAieBU8CypK966vD+2veJio3iu+bfWbL8OgXr8Hmjz5l3ZN6jZjpNe5KI6AjeX/M+dSfX5V7kPWZ2nsmZN87wbr13yZ0x97/mz+qVlVYlWrHjxR381PIntpzfQoXfKrDx3EYLok/7Lty+QK1JtTh24xjzus/j+xbfJ/sSXpFsRfis8Wecf/M80ztNxyeDD2+vfBvfH3zpOqcr84/MJ+xhWMqsQBoiIhQvXpxevXrRpk0bvvvuO7p3756qO9oltSn+Kk9+JvuJx72plAoEAuNNG2nz90OgWwLlPgcS7E2mlNoJlH9CXKlW8MVgpuydwn/q/IfiOYpbFsfbdd7mr8N/MTRwKI39GpPTO6dlsWip35HQI/SY24MD1w4wsMpAfmjxA1k8sySprKuLK6/XfJ3OZTrTbFoz2s5sy7oB66iav2oKR+087kfep8OsDtyPvM+WF7ZQIU+FZ6rP082TPhX70KdiHw5dO8TkPZOZun8q847Mw0VcqJ6/Og0KN6BAlgLky5SPvJny2mlN0p4CBQrQp08fli5dSr169diyZUuq7GCX1Ke7BaRwHOmOUoo3lr9Bnox5+KDBB5bG4ubixuQOk6k6vipvrXiLaZ2mPbmQli6tOb2GLnO64OnmyZJeS55qqGOAAlkKsKrfKupNrkfLGS3Z+NxGyuTSz5N6klgVy3MLn2Pvlb0s7rX4mZN6fOVyl+P7Ft8zqukotodsZ/Xp1aw6vYoft/9IdGxS7mx2fu7u7nTo0IEpU6YQHBxMvXr1rA7pX9J3TwkL/XnwT7aFbOPLJl8m+WwnJVXMU5H3673P9P3TCTwR+OQCWrozcfdEWs5oScGsBdnx4o6nTupxCmQpwOr+q3EVV5pNa8a5sHN2itR5fbrhU+Yensu3zb595u3/OO6u7tQvXJ9PGn3C1oFbifgwgmvDr7H/5f2s6LsixZabVogIuXLlYufOnVaHkiCd2C0QHRvNh2s/pEreKjxX+Tmrw3nkgwYfUC5XOV5a8pIeclZ7RCnFB2s+YNDiQTTxa8Lm5zfb7e6N4jmKs7LfSu5F3qPfgn7EKv2UrsSsPbOWTzZ8wnOVn2NY7WEOXbaLuJArYy4q5KlA82LJvuPY6dy+fZsTJ07QrJl9hvy2N53YLfDXob84E3aG/zb8b6q6vcTD1YPJHSZz8c5FPl7/sdXhaKmAUophK4bx5eYvGeQ/iCW9l5DVK6tdl1ExT0V+avkTm85vYtzOcXat21lExkQyNHAoftn8GNt6rL5V0EJ37txh4cKFvPHGG5QrV87qcBKUrKwiIt1EJLP594ciMt/sEa8lkVKKr7d8TZmcZWhXqp3V4fxLDd8aDPIfxC87fuHQtUNWh6NZKFbF8tqy1xgdNJo3ar7BuLbjcHNJ7phWSdO/Un+aF2vOf1b/h/O3z6fIMtKyn4N+5sj1I/zU8icyuGewOpx06+TJk/z+++/07duXkSNHPrmARZJ7uviRUuquiNQDmmLcovab/cNyXitOrWDf1X38p+5/UtXZuq0vmnxBFs8svL789VR/v6aWMmJVLK8ufZUxwWMYXns4P7b4MUXPEkWEcW3HoZTi5SX6GQa2Lt29xCcbPqFNiTap8mQgPQgLC2Px4sWsXLmS+fPn88knn+Dq6mp1WIlKbmaJMX+3AcYrpZYCHvYNybmN2jyKAlkK0LtCb6tDSVRO75x81ugz1p5Zy7wj86wOR3MwpRRvLHuDcbvG8V699/im2TcOafotkq0IXzb5kmUnlzHzwMwUX15aMXzlcKJiovip5U9Wh5LuPHjwgLVr1zJ58mSaN2/OiRMnCAgIsDqsJ0puYr8oIuOAHkCgiHg+RR3p1rYL29hwbgNv134bD9fUfTz0UrWXqJinIsNWDNOPd01nPlz7Ib8G/8rbtd/mi8ZfOPR67pDqQ6hdoDZvrniTe5H3HLbc1GrD2Q38efBP/lP3PxTLUczqcNKNe/fusXbtWsaOHYufnx+HDx/myy+/JEsW6+9gSorkJuXuGKPHtVBKhQE5gHfsHZSz+nrL1+TIkIMX/V+0OpQncnNx45dWv3DhzgVGbR5ldTiag4zaPOpRR7lvm33r8E5ari6u/NDiB66HX+e3YH2V77/r/4tvZl9G1Bvx5Jm1Z3br1i1WrFjBuHHjKF26NPv27WPKlCn4+ib44NBUK1mJXSkVDlwD4u7Ij+YJI85phqPXj7Lw2EJeq/EamTwyWR1OkjQo3IBe5Xvx7dZv9T3G6cBvwb/x3pr36F2hN7+1+c2ynte1CtSiebHmfLv1W8Kjwi2JITUICgliw7kNDKs9DG93b6vDcWohISH8/fffTJkyhXr16nHixAnGjRuHn5+f1aE9leT2iv8v8C7wnjnJHZhu76Cc0fhd43F3cefV6q9aHUqyjGo6ChFhxBp9xuDM/jr0F0MCh9C2ZFumdJiCq4u1HYNGNhhJaHhour797estX5PNKxuD/AdZHYpTio2N5ejRo0yfPp3AwEAGDBjAhQsX+Oabb8iTJ4/V4T2T5DbFdwLaA/cBlFKXgMz2DsrZRERHMHXfVDqW7pjgAzJSs0JZCzG89nBmHZzFtgvbrA5HSwFrz6yl74K+1ClYh9ldZyf7YSIpoW6hujT2a8w3W7/hQdQDq8NxuGPXj/H30b8ZUn0ImT31LtaeoqOj2b17NxMmTODQoUN8/vnnnDt3jjfffJPMmZ1jWyc3sUcq4z4UBWA+l117gr+P/s2NBzfSxLX1hLxb713yZcrHWyve0iODOZk9l/fQcVZHSuQowaJei1JVk+/IBiO5cu8KE3ZPsDoUh/tu63d4unnyes3XrQ7FaURGRrJ161bGjh3LvXv3mDFjBvv27aNHjx64uaXM+AxWSW5in2P2is8mIoOA1UD6+9Yl08Q9EymctTBNiza1OpSnkskjE182+ZKgi0HMOjjL6nA0Ozl96zStZrQim1c2lvddTo4MOawO6R8aFmlIw8IN+XrL1zyMTr2PyLS3y3cvM3X/VJ6v/Hyaa+FLjWwTesaMGVm7di1r1qyhUaNGTjuCX3I7z30HzAXmAaWAkUqpX1IiMGdx+tZpVp9ezcAqA1PtgDRJ0b9Sf/zz+TNi9Yh02TTqbK6HX6fl9JZExkSyou8KCmQpYHVICfqowUdcunuJGftnWB2Kw4zePpro2GiG1xludShpWkxMDDt27HiU0Ddt2sT8+fOpVKmS1aGluGRnGqXUKqXUO0qp4UqpVSkRlDOZvGcyLuLC81WetzqUZ+IiLvzY4kcu3LnAd1u/szoc7RmER4XT7s92XLhzgcW9Fqfqx6U29mtM2VxlGb97vNWhOMTD6IdM2D2BzmU6UzR7UavDSbNOnz7N77//zp07d9iwYQPz58+nfPnyVoflMElK7CKy2fx9V0Tu2PzcFZE7KRti2hUdG83ve3+nVfFWqfaMKDkaFG5A17JdGbVlFCF3QqwOR3sK0bHR9JrXi6CQIGZ2nkndQnWtDumxRITB/oPZcXEHe6/stTqcFLfo2CJuPbzFYP/BVoeSJkVGRrJkyRJWr17N6NGj2bhxIxUrVrQ6LIdLUmJXStUzf2dWSmWx+cmslEobQ/FYYNmJZVy6eynNdppLyLfNviUmNoYRq/Xtb2mNUorXAl9j0bFF/NLqFzqV6WR1SEnSr1I/PF09mbDL+bvzTN4zmUJZC9HYr7HVoaQ5V69eZcqUKZQsWZLjx4/TpUsXp72G/iTJvY89RwI/1t8bk0pN2jOJvJny0qZEG6tDsZsi2YrwTp13mHFgBlsvbLU6HC0Zvtr8Ff/b9T/erfsuQ2oMsTqcJMuRIQfdynVj+oHpTj288YXbF1h5aiUDKg2wfByBtObSpUvMnDmTzz//nBkzZpAxY/q+YSu519h3A6HAcYwR50KBsyKyW0Sq2ju4tCzsYRiBJwLpXb53qrgv2J5G1BuBb2Zf3lj+hr79LY2Yum8qH6z9gD4V+vBlky+tDifZXqr6Enci7jD70GyrQ0kxU/dNRaF4rvJzVoeSpoSFhTF37lwmT57M88+n7b5M9pLcxL4KaK2UyqmU8gFaAUuAV4Gx9g4uLVt4dCFRsVH0KN/D6lDsLqNHRr5u+jU7L+1k6r6pVoejPcGqU6sYuGggTfyaMLnD5DR5d0bdgnUpk7MM43c5Zye6WBXL5L2TaVSkke40l0wbN25k6NChdO7c2epQUo3k3pVfSyn1aHxDpdRKEflOKfWS+aQ3zTT70GyKZCtC9fzVrQ4lRfSu0JsxwWN4d/W7tC/VPtXdA+0oYQ/CCLoUxP4r+zl24xjnws5xO+I29yLvER4VToyKwQUXRAQ3FzeyembFx9uHXBlzUcanDHUL1aV2gdp4uXulSHx7Lu+h85zOlM1Vlnnd56X6pwomRkQYXHUwb614i31X9lEpr3PdsrTp3CZO3zrNxw0/tjqUNCUyMpJjx46xfPlyq0NJVZKb2C+LyLtA3CglPYCrIuIK6DZZ080HN1l1ehXDag1z2s4bIsJvbX6j6viqvLPyHSZ1mGR1SCnu4p2LzD08l8ATgRy5foSr968SGROZ4LyCkchFBGOwRuOsLEbFJDi/p6snhbIWooZvDTqW6kjHMh1xc3m20bDOhp2l9czWZPfKzrI+y8jqlfWZ6rNav4r9GLF6BBN2T+DX1r9aHY5d/b73dzJ7ZKZL2S5Wh5Km3L9/nwwZMpArVy6rQ0lVkrvn6A38F/gbY1jZLeY0V4xHumrAgiMLiI6Npns5594klfJW4p067zBqyyj6VOzjdD15b4TfYNq+acw6NIv9V/fzIPr/B+ZxERd8MvhQLHsxyuUuR9lcZamUpxJV8lYhe4bsjz2gC3sYxokbJwi6GMSuy7s4GnqUU7dOcfLmSU7cPMGMAzNwEReKZi9Ku5LtGFZ7WLJvl7wRfoOW01vyMPoha15YQ/7M+Z96O6QWPt4+dCzdkdmHZjO65ehnPvBJLe5G3OWvw3/Rt0LfVDWkb1qQLVs2IiIiuHjxYpp7tGpKSvI3wzwr/0kp1SeRWU7aJ6S0b87hORTNXhT/fP5Wh5LiRjYcydwjcxm8eDAHXjlABvcMVof0TI5eP8oP235g8bHFXLl/5dH0jO4ZqZG/Bs2KNaNHuR6Uy13uqa9VZ/PKRnXf6lT3/edlmtjYWNadXcesg7NYeXolp26e4sftP/Lj9h8pmKUgz1d+nnfrvfvEnf+DqAe0n9Wes2FnWdVvFWVzlX2qOFOjHuV6MPvQbNadWUezYs2sDsculp5YSnhUOH0r9rU6lDRHRKhYsSKvvvoqf//9t9O2kCZXkvdMSqkYoLCIpM2LdA5yPfw6a06voUe5HuniQ5bBPQPj247n1K1TfLLhE6vDeSrHrh+j3/x+ZP86O2XGlGHC7glcu3+NUj6leKfOOxwfepx7798jaFAQnzf+nAp5KqRIBzQXFxeaFG3ChPYTOPfmOcI/CGdMqzFUyF2BkDshfLrxUzJ9mYkGvzdg35V9CdYRHRtNz3k92XZhG9M7T6d+4fp2j9NKLYu3JJNHJuYcmmN1KHYz78g88mbKm+oHC0qtAgIC2Lt3L1988cWjy17pXXLbsk4DW0RkEeajWwGUUj88qaCItAR+wmi2n6iUGhXvfU9gKlAVuAH0UEqdFREfjPHpqwNTlFJDbcqsB/IBcW2kzZVS15K5TnY1/8h8YlSM0zfD22rk14gXKr/Ad1u/o2vZrlTLX82hy78RfoMlx5dw4NoBDoce5uj1o0THRpM7Y25yZ8xNoayF6Fi6I038mjy69fDEjROM2jyKhccWcuPBDQDcXNyo6VuTQf6D6FOxD15uKdOhLam83Lx4tcarvFrjVe5H3mfU5lFM2D2BTec3UXlcZYpmL8q3zb6lcxmjN7BSiiFLhzwagKZr2a6Wxp8SMrhnoH2p9sw/Op+xbcam+VtJw6PCCTwRyIBKA9Lk3Qqpgbu7O507d2bcuHEcO3aMCRMm4OVl7XfXaslN7KfMHxeS8Rx2sxl/DNAMCAGCRWSRUuqwzWwDgVtKqeIi0hP4GqNz3kPgI6C8+RNfH6XUzmSuR4qZc2gOJX1KUimPc/XafZLvmn/HqtOr6DKnC7sG7yKnd84UXV5kTCSBJwKZum8qS44vISo2Ci83L0r5lKJmgZp4unoSGh7KtfvX2HJhC+N2jSNHhhwUzlqYs2FnufXwFgCu4koN3xq8XuN1epbvmWoHBsnokZHPGn/GZ40/Y/Wp1QxfNZx9V/fRZU4XCmUpRGfPzpyJPMPC8wt5v977DK0x9MmVplHdy3Zn5oGZrD2zlhbFW1gdzjNZfnI54VHhdCmjO809i2zZstG/f38CAwOpUaMGf/zxB1WqVLE6LMskK7ErpT4BEBFvpVR4MorWAE4qpU6b5WcBHQDbxN4B+Nj8ey7wq4iIUuo+sFlEiicnVitcu3+NdWfX8X6999NFM7yt7BmyM7/HfOpNrkfPuT1Z3nd5inRuioyJZMreKXyx6QvO3z5Pnox5eL3m6/Sp0IeKeSr+KzFHxUQxevtofgr6iYt3L3LzwU0ACmQpwEf1P2Kg/8BUm8wT07RYU/YW28upm6fot6Af20K2MZrRAHQs1ZHPG39ubYAprEXxFmTxzMKcQ3PSfGKfd2QePhl8aFikodWhpHkeHh506NCBPXv20LhxY3r27MlXX31FtmzZrA7N4ZI7pGxtETkMHDVfVxKRpAxM4wtcsHkdYk5LcB6lVDRwG/BJQt2/i8heEflIEsmmIjJYRHaKyM7Q0NAkVPl0Fh9bTKyKdcom0KSolr8av7X5jTVn1vD+mvftWnd0bDQTd0+k5C8leWnJS+TLlI9FPRcRMiyE75p/R5V8VR4l6NjYWMbvGk+V/1XB6wsv/rP6P1y8exG/bH68V+892pdsT8idEEauH8mkPZPS7HW5YjmKsXXgVn5u+fOjaX8f+5uOszpyL/KehZGlLC83LzqU6sD8o/MTvd0wLYiIjmDxscV0LP3stzZqBhHB39+fwYMHs3v3booXL873339PeHhyzkPTvuRe1BkNtMC4Bo5Sah/QwM4xJUcfpVQFoL750y+hmZRS45VS1ZRS1VLyfsclJ5ZQKGshKuZJf08TivN8led5pdorfLv1W2YffPbhP5VSLDiygPJjyzNo8SDyZMrDsj7L2DZwG+1KtXu0Q4yKieLXHb/iP84fj889eGnJS+y9upc8GfPwRs03CH0nlNNvnObLJl+ysNdCtr6wlVI5S/HSkpfo9lc3bj+8/cyxWmHtmbUMXzWcYh7FGJprKLm8c7Ho+CJ8vvHhl6BfrA4vxXQv152wh2GsPr3a6lCe2qrTq7gbeVc3w6cAb29vWrduTbdu3Zg6dSqFCxfmp59+4uHDh1aH5hBP8zz2C/EmJTzixj9dBAravC5gTktwHhFxA7JiHkA8JpaL5u+7wEyMJn9LPIx+yKpTq2hbom26a4aPb3TL0dQtWJe+C/ryW/BvT1WHUoq1Z9ZS7/d6dJ7TGRHh7x5/s33gdloWb4mIEHInhHdWvkPJX0ri9YUXry17jT1X9pDTOyeD/Adx7s1zXHr7EqNbjv7XNf/aBWuzfsB6vm32LX8f/ZtqE6qluceCBl8MpsOsDpT0Kcmbud+kqndVrr1zjf82+C+xKpbXl79Oxd8qcuXelSdXlsY0L9acrJ5Z03Tv+HlH5pHVMytNijaxOhSnlTdvXjp37kyXLl2YOHEiBQsW5PPPP+fmzZtWh5aikpvYL4hIHUCJiLuIDAeOJKFcMFBCRPzM2+V6AovizbMIGGD+3RVYqx7TRioibiKS0/zbHWgLHEze6tjPhrMbuB91n7Yl21oVQqrh4erB0t5LaVGsBa8GvsorS15JcpOpUorAE4HUnVyXJlObcObWGca1HceBVw5Qv1B9ftj2Aw1+b0DWUVkp+GNBvtv2HSdunsA3sy+v13idi8MucmX4Fca3G0+hrIUeuywRYXid4Wx4bgMPoh5Qa2ItZh2c9dgyqcXBawdpNaMVubxzsaLvCjK5Znr03seNPubiWxepnLcyB64doOCPBfl+6/cWRmt/Hq4edCrTib+P/k1EdITV4SRbVEwUC48upF2pdml2mN+0JF++fHTt2pVu3bqxcOFCihQpwpAhQzhz5ozVoaWI5Cb2l4EhGNfDLwKVzdePZV4zHwqswDgQmKOUOiQin4pIe3O2SYCPiJwEhgGPHvgtImeBH4DnRCRERMoCnsAKEdkP7DXjseyBzUuOL8Hb3ZtGfo2sCiFVyeqVlYU9F/Ju3Xf5367/0WxaM1adWpXgtV+lFAeuHuC/6/5LubHlaDOzDWfCztC1TFfqFazH91u/J8tXWfD51ofhq4az6fwmomOjqelbk59b/kz4++Gcf+s8P7X66alGWKtbqC57XtpDzQI16TWvF19v/jpVX3c/fuM4Tac2xcPVg1X9ViW4zrkz5WbPS3sY23osgjB81XDqTKpDeKTzXGvsWqYrtyNus+HcBqtDSbZ1Z9dx6+EtupZJn/1xrJInTx7atm3LoEGDOHjwIJUrV6Z169asXbs2VX/nkyu5veKvA4mNPPeksoFAYLxpI23+fgh0S6RskUSqTRWPilVKseTEEpoWbWr5vc+piauLK581+oxMHpn4dMOnNJ/eHEHI7JIZD/FgxHcjeBD9gAdRD4iKjQKMMdYBrty7wtwjcx9Ny5EhB5XzVqZ5sea8UOWFJ56NJ1eujLlY2Xclzy18jhFrRnA27Cy/tP4l1XVqOn3rNI3/aEysimXdgHUUy1HssfO/Uv0VupTpQoMpDdgWso083+chsHegUwxc09ivMRncMrD0+FKaF2tudTjJsvjYYjK4ZUhzcTuLLFmy0LhxY+rVq8f+/fvp378/3t7eDBs2jH79+qX557kna68lIrmAQUAR27JKqRfsG1bacjj0MGfDzvJ+Pfv2BE+Ldl/azeS9k1l7Zi3nbp8jPOqfZ4gKxZ3YO8aL+/8/XRAyuGUgq1dWcmfMTSmfUlTOW5mGRRpSq0Athwze4enmyYzOMyiStQijtowi5G4Is7vOTjXjd5+/fZ4mU5vwIPoB6waso0yuMkkqlztTbo4OPcoby97g5x0/02BKA0Y2GMknjdLmSIFxMrhnoLFfY5acWMLolqPTVN+WZSeX0civUZofgjmt8/DwoFq1alStWpUzZ84wduxY3n33Xfr168frr79OyZIlrQ7xqST3dGQhsAlYTdI6zaULS44vAaB1idYWR+J4sbGxzDk0h593/MzOSzsfnXkDZPfKTrHsxSjpU5IqeauQO2NuMntmJmhjEBlcMjC4x2CyZchGBrcMeLqljqf+uogLXzX9ikJZCzEkcAjNpzVnca/FZM+Q3dK44s7Ubz28xZr+a57qzoufWv1ElzJdaDmjJZ9u/JRN5zexst/KVNcqkRxtSrRh6YmlHLtxjNI5S1sdTpKcuHGCU7dO8Vatt6wORTOJCEWLFqVo0aKEhYWxe/duatSoQeXKlXnrrbdo27Ytrq5pZ7yL5H6jvZVS76ZIJGnYkhNL8M/nj2+W9PN0of1X9/PW8rfYdH7To2SeI0MO6hasS/dy3elWtluiyfrhTuOWkyLZizgq3GR7pfor5MqYiz7z+1D/9/qs6LvCsv/vsevHHp2pr+2/lqr5n/4KVIMiDQh5K4RqE6qx7uw6Cv5YkOBBwcl+elxq0aZkGwg0Dq7TSmIPPGFckWxVopXFkWgJyZYtG40bN6Z+/focPnyYYcOG8corrzBkyBAGDx6cJh4Rm9z2zSUikv5OSx/jRvgNtl7YStsSzt8bXinFuJ3jKDK6CJX+V4m1Z9eS0SMjfSv05eiQo9z4zw0W9VpE34p9U80Z+LPoWrYry/os49ztc9SZXIdD1w45PIZD1w7RcEpDImMiWTdg3TMl9Tg5vHNw8rWTdCrdiSv3rlD85+Jsu7DNDtE6XqGshaiQuwJLTyy1OpQkW3ZyGSV9SlI0e1GrQ9Eew93dnUqVKtG/f3/atWvHwoUL8fPzo2fPngQFBVkd3mMlN7G/gZHcH4rIHRG5KyJ3UiKwtGL5yeXEqlinv83t1x2/kuObHLy89GXO3T5H5TyVWd5nObfevcW0ztMolbOU1SGmiMZ+jdnw3AYiYyKpO7kua06vcdiy159dT/3f6+Pq4srG5zfadeAjFxcX5veYz1dNviIiJoJ6v9djxoEZdqvfkdqWbMumc5sIexhmdShPFB4Vzvqz62ldXJ8fpSX58+enTZs2DBkyhFu3btGuXTsqV67MtGnTiIhIfbdbJiuxK6UyK6VclFJeSqks5ussKRVcWrDkxBLyZMxjlzOp1GjK3in4fO3Da8te407EHTqU6sDlYZfZ8/KeND9Od1L55/Nn+8DtFMhSgJYzWjJl75QUX+Yfe/+g+bTm5M2Ul83Pb06xZuYR9UYwv/t8BKHv/L6MXDfyyYVSmTYl2hCjYlh5aqXVoTzRujPriIiJ0M3waZS3tzd16tThlVdeoUyZMnz11Vf4+vry4YcfcvXqVavDeyS5Y8WLiPQVkY/M1wVFxLLR3qwWq2JZeWolLYu3dLpHLh68epASv5Tg+YXPc+vhLdqVbMfV4Vf5u+ff5M2c1+rwHK5wtsJseWELAUUCeH7h87y94u0UGac8VsXy4doPeW7hczQo3ICtA7fil93P7sux1alMJ3YO2om3uzefbfyMQYsGpejy7K1WgVrkyJAjTTTHLzu5DG93bxoUtnIkbu1Zubi4ULp0aXr06EHPnj1ZvXo1xYsXp2/fvuzbt8/q8JLdFD8WqA30Nl/fw3gca7q098pebj64SbOizawOxW4ioiPoNKsTFf5XgZM3T1Ijfw1ChoWwqNeiFH8Ua2qX1Ssrgb0DGVJ9CD9s/4F6k+tx+tZpu9UfdzvbF5u+4MUqL7KszzKyeWWzW/2PUzlfZU69foocGXIwcc9EOs3q5JDl2oOriyutirci8EQgMbGp92YdpRTLTi6jsV9jPd6FE8mVKxetWrXi1Vdf5erVqzRu3JiGDRtaOuhNchN7TaXUEIxnpKOUugWk2/EQV51aBUDTok0tjsQ+lp1YRs5vc/L3sb/xyeBDYO9AggYFPdVobs7K3dWdX1v/ytxuczl+4zhVxlVh5oGZz/QFVkoxff90KvxWgZ2XdjKp/STGtxuPu6u7HSN/sryZ8nLm9TP4Zvbl72N/U39yfWJjYx0aw9NqU6IN18OvE3wp2OpQEnX8xnFO3zpNq+K6Gd4ZeXt7U69ePV599VWyZ89O37598ff3Z8GCBQ7/HiU3sUeJiCug4NGANWnjm58CVp9ZTYXcFciTKY/VoTyTyJhI2v/ZntYzW3M/8j5Dqg8h9J1QfR3wMbqU7cLel/dSNldZ+szvQ53Jddh8fnOy69l2YRutZrSi34J+VMxTkf0v7+eFKi9YNthKFq8snH79NCV9SrL5wmaqT6ieJpJ7y+ItcRVXlh5Pvc3xy04uA9CJ3cm5ublRpUoVBg0aRKlSpXj77bcpW7YsCxcudNgZfHIT+8/AAiC3iHwBbAa+tHtUacCDqAdsOrcpzZ+t7768m9zf5mbx8cXkyZiHPS/t4dfWv6apUbysUiRbETY9v4mJ7SZy/vZ56v9enw6zOrDw6ELuR95PtFxEdASrTq2i2bRm1Jlch12Xd/F98+9ZP2B9il9PTwoPNw+OvHqEynkqs/vKbqpOqJrqk3v2DNmp7lud1WdS72Ncl59cTimfUqnif6ylPBcXF8qUKUP//v3x9/fntddeo0qVKqxatSrFl53cseJniMguoAkgQEelVFKe7uZ0tl7YSkRMRJpO7F9t+ooP1n6AQvFC5ReY2H6iTujJ5ObixkD/gfSq0IvR20fz7dZvWXRsEZ6unjT2a0ylPJXwdPPEy82Le5H32Hx+M9tDthMRE0GejHn4rtl3vFztZTJ6pK6xqV1cXNg1eBfVJ1Zn9+XdVB5Xmb0v7cXFJfV2Em3q15QvN3/J7Ye3yeqV1epw/iEyJpKN5zbyov+LVoeiOZiIUKpUKUqUKMHhw4fp168f1atXZ8yYMRQqZN9nXsRJ9liSSqmjwNEUiCVNWXV6Fe4u7mmyd2tkTCRN/mjC5gub8XT15K9uf9GuVDurw0rTvN29eb/++wyvM5zN5zez+NhilpxYwpozax71nncRF/zz+TOk+hAaFG5A82LNU/VY4S4uLgS/GEzNiTXZeXlnqk/uTYs25fNNn7Ph3Abal2r/5AIOFBQSxIPoBzT2a2x1KJpFXFxcKF++PKVKlWLbtm1UrFiRESNG8M4779h9uNq0O0i0xVafXk3tgrXJ5JHpyTOnIudun6Pa+GpcD79OyRwl2TJwS7rv7W5PHq4eNPZrTGO/xvzY8kfAuIUtMiYSQdLciHwuLi4EvRhErUm1CL4UTK1Jtdg+cHuqTO61CtTC292b1adXp7rEvvbMWgShYeGGVoeiWczd3Z0GDRpQvnx5Jk+ezKpVq5gzZw4+Pj52W0bq+3amATfCb7D78m6a+qWtZvjlJ5dT8ueSXA+/Tp8KfTg69KhO6g7gIi54uXmluaQex8XFhe0Dt1M+V3mCLwXTdFrq/Nx7unnSoHADVp9OfdfZ155di38+f8sfJqSlHjly5KBnz55ERUVRqVIlDh8+bLe6dWJ/CuvOrkOh0tT19VGbR9F6RmuiYqP4qcVPTO88XV9P15LMxcWFPS/voVj2Yqw7u452M1PnpZsmfk04cv0IF+9ctDqUR+5H3mfbhW26GV77F1dXV5o0aUK1atVo0aIF169ft0u9OrE/hVWnVpHFMwvVfatbHUqSvLjoRd5b8x6ebp5sfG4jr9d63eqQtDTIzcWNg68epECWAiw5sYQXFr5gdUj/EnewveaM48b0f5ItF7YQFRtFE78mVoeipVJVqlShaNGidOvWzS716cT+FFafWU2jIo1S/XOsY2NjaTa1GZP2TCKHVw6ODz1OvcL1rA5LS8O83Lw4MuQIPhl8+H3v76lubPmKeSqS0ztnqkrsa8+sxc3FjXqF9HdPS1zDhg3ZvXs3Fy5ceOa6dGJPptO3TnP61ulU3wwfGR1Jhd8qsPrMavyy+XHurXMUzFrQ6rA0J5DJIxP7X97/aGz5cTvHWR3SIy7iQhO/Jqw+vdqy4TzjW3tmLbUK1Ep1tzRqqYurqytFixZl3bp1z1yXTuzJtO6MsdFT8/Wy+5H3KfZLMQ5fP0wt31qceO1Emuu9r6Vu+bPkZ8eLO3B3ceeVpa+w6Ngiq0N6pGnRply6e4mj162/KzfsYRi7Lu+icZHUu7/QUo8bN25QsmTJZ65HJ/Zk2nh+I7m8c1EmZxmrQ0lQ2MMwiv1cjJA7IbQt0ZZtL27D1cW+90hqGkC53OVY3W81IkLn2Z05ePWg1SEBPLqWnRp6x284u4FYFUuTovr6uvZ4p06dIjw8nOrVn73vlk7sybTh7AYaFG6QKnuUX7t3jaI/FeXq/av0LNeTxb0XWx2S5uQaFGnA7x1+J0bFUGtSLa6H26dX77Pwy+5H0exFU8V19rVn1pLBLQM1fWtaHYqWil2+fJlFixYxf/58uwxWoxN7MpwLO8e52+dS5WhzV+5docSvJbj18BaD/AfxZ9c/rQ5JSyf6V+rPiLojuB91n0r/q0R0bLTVIdHErwnrzq6z/DGua8+upV6heml2DAMtZSml2Lt3L7NmzWLixIk0aGCf3KITezJsPLcRINWNHnU9/DplxpThTsQdXq/xOuPbjbc6JC2d+arpV3Qo1YFLdy9Re2Jtq8MhoEgAdyLusP/qfstiCL0fysFrB2lUpJFlMWip1507d5g3bx7Hjh1jw4YNdO3a1W5168SeDBvPbSSbVzbK5y5vdSiP3Ay/SclfShL2MIxXq7/KT61+sjokLZ2a330+5XOVZ+flnby4yNqHncS1qm04t8GyGOIe49uwSOo6EdCsdffuXVatWsWECRNo3749e/fupVKlSnZdRuq+ETuV2XBuA/UL1U81ndHuPLxDyV9LPmp+H9N6jNUhaelY3LjyBX4swKQ9k6jhW4PBVQdbEkuBLAUomr0oG89t5M1ab1oSw6bzm/By86Ja/mqWLN9e7kXe4/iN49x8cJObD25y5d4Vq0NKk27dukVwcDAHDhxgwIAB/PXXX+TLly9FluWwxC4iLYGfAFdgolJqVLz3PYGpQFXgBtBDKXVWRHyAuUB1YIpSaqhNmarAFCADEAi8oVLo5tXLdy9z4uYJy3ZU8UVER1BmbBluPLjBgEoDdPO7lip4e3gT9GIQZceW5ZWlr1AlbxXLRmhsULgBi48tRillSWfXjec2UtO3Jh6uHg5f9rO49eAWk/ZMYvHxxRwOPZwqOkSmVbGxsZw6dYp9+/Zx/vx5nnvuOebOnZtiCT2OQxK7iLgCY4BmQAgQLCKLlFK2o94PBG4ppYqLSE/ga6AH8BD4CChv/tj6DRgEBGEk9pbAspRYh03nNwGp4/p6bGwsFX+ryKW7l+hUuhNTOk6xOiRNe6SETwnmdptLx9kdCfgjgHNvnrPkYUMNCjVgyt4pHLl+hLK5yjp02Xcj7rLnyh7er/e+Q5f7tCJjIvl267dM2TuFUzdPoTDOjwQhd8bclMhRgpzeOcnlnYtc3rn4iq8sjjh1u3v3Lvv372f//v3kzJmTt956i549e5Ixo2MGKXLUGXsN4KRS6jSAiMwCOgC2ib0D8LH591zgVxERpdR9YLOIFLetUETyAVmUUtvN11OBjqRQYt9wdgOZPDJRJV+VlKg+yZRS1J5Um+M3j1OvYD3m95hvaTyalpAOpTvwYf0P+XzT59ScWJMTQ084/FGvcde2N5zd4PDEvi1kG7EqlvqF6zt0ucl1M/wmry17jb8O/0VUbBRgXMboXLozAyoNoFzucgn26NeJ/d+ioqI4duwYR44c4fz583Ts2JFPP/2UmjVrOrzFyFGJ3RewHQA3BIh/Y+ejeZRS0SJyG/ABEmsH8jXrsa3TN6EZRWQwMBigUKFCyY0dMAamqVuwruXjw7ed2ZYdl3ZQPld5NjxnXccgTXuSzxp/xubzm1l/bj295/dmVtdZDl2+XzY/fDP7svH8Rl6p/opDl73p3CZcxIXaBay/QyAh9yLv0Xd+XxYdW4RCkcEtAy9WeZFPGn1Croy5rA4vzYiNjeX8+fMcOXKEw4cPU6VKFd577z06deqEt7e3ZXGli85zSqnxwHiAatWqJfsa/PXw6xy8dpBe5XvZPbbkeC3wNQJPBlIwS0F2v7Tb4WdAmpZcq/qvwvd7X2Yfmk1jv8YO7aMiIjQo3IAN5zY4/Dr7pvObqJK3Cpk9MztsmUkRExvDR+s+4rut3xEVG0WODDn4qMFHvFHzjVQ56FZqdeXKFQ4dOsSRI0fw8fHhueee46+//qJgwdTxPA5HJfaLgO0aFzCnJTRPiIi4AVkxOtE9rs4CT6jTLuJuW7FyYJrR20fza/CvZPXMyoFXDuDu6m5ZLJqWVG4ubmx/cTslfy3JK0tfoVaBWlTMU9Fhy29YuCF/HvyTU7dOUTxH8ScXsIOI6AiCLgbxSjXHthI8SVBIEG3/bMv18Ot4uHrwccOPGdlwpE7oSRQWFsbBgwc5evQo0dHR9O3blzFjxlChQgWrQ/sXRyX2YKCEiPhhJN+eQO948ywCBgDbgK7A2sf1cFdKXRaROyJSC6PzXH/gl5QIfsPZDXi5eVE9vzW9excfW8xbK97Cw9WDPS/tIatXVkvi0LSn4Zfdjz+7/Em3v7rR4PcGXBl+BS83L4csO+5gfOO5jQ5L7Lsu7+Jh9EPqF0od19cjYyIZGjiUCbsnANCuZDtmdpmpHwyVBA8ePODQoUMcP36cq1ev0rlzZz766CPq1auXqltMHZLYzWvmQ4EVGLe7TVZKHRKRT4GdSqlFwCRgmoicBG5iJH8AROQskAXwEJGOQHOzR/2r/P/tbstIoY5zG89vpFaBWpYMC7n/6n46ze6Ei7iwpv8a/LL7OTwGTXtWXct25SX/lxi3exxNpzZl8wubHbLc0jlLk8s7FxvPbeSFKi84ZJmbzhl30KSG568fu36MRn804vK9y3i7ezOr6yzalWxndVipWkxMDCdPnuTw4cOcPHmSpk2b8s0339CyZUs8PdPG0MAOu8aulArEuCXNdtpIm78fAt0SKVskkek7+fctcHZ1L/Ie+67s471676XkYhJ068Et6k6qS4yKYVqnaaliR6FpT+t/7f7H2rNr2XJhC19s/IIPGnyQ4suMu84eNxy0I2w6v8k4oLC4E9rMAzMZ8PcAomOjqVuwLkt6LyGbVzZLY0rNrly5woEDBzh06BDFihVjyJAhdO/enaxZ014LaeptS0glgi8GE6NiqFOwjkOXGxMbg/94f+5F3eM/df5D34p9Hbp8TUsJWwduxdPVk4/WfUTwxWCHLLNB4QacCTvDhdsXnjzzM4qJjWHz+c2WNsNHxUQxaPEg+szvQ3RsNO/Xe59Nz2/SST0BkZGR7Nmzh6lTp7JgwQLq169PUFAQO3fuZNCgQWkyqUM66RX/LLZe2ApArQK1HLrcVjNacTbsLE39mvJ1s68dumxNSyk5vXMyv8d82sxsQ9NpTbk6/GqKX2+3vc7ep2KfFF3WwWsHuR1x27LEfjfiLi2mt2BbyDbcXdyZ03UOHct0tCSW1Cw0NJQ9e/Zw4MABatWqxejRo2nVqhVubs6REvUZ+xNsDdlK2VxlyZ4hu8OW+e6qd1l1ehWFsxZmed/lDluupjlC6xKteaXaK9yJuEPzac1TfHkVclcgs0fmRwfpKWnLhS2ANdfXL929RNXxVdkWso0cGXKw56U9OqnbUEpx+vRp5syZw6xZs2jYsCEHDhxg5cqVtGvXzmmSOugz9seKVbFsu7CNLmW6OGyZfx/9m2+2fkNG94zseWlPqnngjKbZ09g2Y1l1ehWbzm9i9PbRKfqgFlcXV2oVqMXWkJRP7FsvbCVfpnwUyVYkxZdl69C1QzT6oxGh4aEUyFyArQO3UjBr6rin2mqxsbEcPHiQnTt34uHhwbvvvkvfvn3x8nLMnRlW0Gfsj3H0+lFuPbxF3UJ1HbK8s7fO0v2v7riICxue2+DQVgJNc7RNz2/C3cWdt1e+zYkbJ1J0WXUK1mH/1f3cjbibosvZFrKN2gVrO/Te8D2X91B7Um1Cw0MpnbM0u1/arZM6RkLfv38/EyZMICQkhP/9738cO3aMF1980amTOujE/lhxTXeO6DgXFRNFzUk1iYqN4ueWP1M1f9UUX6amWSlvprz83vF3YlUsDaY0IDY2NsWWVbdgXWJVLEEXg1JsGVfvXeX0rdPUKeC4jrY7Lu6g/u/1uRt5F/98/mwfuN3y3vhWU0px5MgRJk6cyPnz55k6dSrbt2+nVatWqfrec3tKH2v5lLZe2IpPBh9K5CiR4stqMrUJ1+5fo3u57gypMSTFl6dpqUGfCn1oX7I9V+5doff8+GNW2U/NAjURhC3nt6TYMraFbAOgdkHHjA+/9cJWAqYEcD/qPlXyVmH9gPXpfvCqq1evMmvWLHbv3s2kSZPYsWMHTZs2TXej6+nE/hhbL2ylTsE6Kf6h+GjtR2w6v4niOYozq4tjH5ShaVab12MePhl8mH1oNoEnAp9c4Clk8cxChTwVHnVuSwlbL2zFw9UD/3z+KbaMODsv7aTZtGY8jH5I+dzlWTtgbaobl96RIiIiWLlyJbNnz+a1117j8OHDtGzZMt0l9Dg6sSfievh1jt04luLN8JvObeKLTV+QwS0DQS8GpdsPopZ+ubm4sbLfSgSh25xu3Iu8lyLLqVuwLttDthMTG5Mi9W8L2YZ/Pv8Uv33vSOgRmk5tyoOoB5TOWZr1A9an63vUT506xcSJE/Hz8+PEiRMMGTLEqXq4Pw2d2BOxPWQ7kLLX1+88vEPLGS1RKJb0WkKODDlSbFmalpr55/NneJ3hhEeH02J6ixRZRp2CdbgbeZeD1w7ave7ImEiCLwan+PX1s2FnafRHI+5G3MU3sy9rB6zFx9snRZeZWkVFRbFixQpWr17NtGnTmD59Ojly6H0o6MSeqC3nt+Dm4paiD36p93s9wqPC+U+d/9C4aOMUW46mpQXfNPuGEjlKsPXCVsYGj7V7/XULGne3pMT97Huv7CUiJiJFr69fu3+Nxn80JjQ8lMyemVkzYA15M+VNseWlZtevX+ePP/4gb968HDlyhBYtUuZgMK3SiT0RW0O24p/PnwzuGVKk/jeXv8mBawfwz+uvR5bTNNP6Aetxc3HjjeVvcOnOJbvWXSRbEfJmypsi19lT+g6aB1EPaDezHedun8PdxZ0VfVdQ0qdkiiwrtTt69CjTpk3jgw8+YN68eWl22NeUpBN7AqJiothxcUeKNautPbOWn4J+IpNHJjY+77iHU2haapc/S35+afkL0bHRNJnaxK51iwh1C9ZNkTP2bSHbKJS1EPkz57d73bEqln4L+rHj0g6UUvzV7S9qFqhp9+WkdkoptmzZwtq1a1m5ciUvv/yy7pOUCJ3YE7D3yl4eRj9MkaPve5H3aP9newRheZ/lZPTIaPdlaFpa9nL1l6mRvwZHbxzl0w2f2rXuOgXrcCbsDJfvXrZrvXF30KSE91a/x7wj8wD4vvn3tCuV/h67Ghsby/Lly7l8+TK7d++mRo0aVoeUqunEnoCUvB+18R+NuR91n7drv+2wEe00La1Z2W8lnq6efLLhE07dPGW3elPiOvuF2xcIuRNC7QL2319M2j2Jb7Z+A8DAygNTdOjd1Co6OpqFCxfi4eHB1q1b8fX1tTqkVE8n9gQEXQwif+b8FMhSwK71frHxC4IvBVM2Z1m+bf6tXevWNGeS1Ssrv3cwRqWzZ5N8lXxV8HLzsut19rgTAXufsW+9sJWXl76MIDQo1ICxbcemu6bn6Oho/v77b3x9fVm5ciWZM6ffe/WTQyf2BASFBFHT177XsPZf3c9H6z7C09WTTc9vsmvdmuaMelXoReMijTl3+xxvr3zbLnV6uHpQLX81u56xb7uwjQxuGaiUp5Ld6rx09xKdZndCKUXBLAWZ12MeHq4edqs/LYiJiWHRokUULFiQBQsWOP347vakE3s818Ovc+rWKbsm9pjYGJpMbYJCMbvrbHJ463stNS0plvZZire7Nz9u+5EjoUfsUmftArXZc2UPEdERdqlv+8XtVMtfDXdXd7vUFxEdQafZnbgefh1XF1cW9lpITu+cdqk7rVBKsWLFCnx8fFiwYAEeHunroOZZ6cQez46LOwCoVaCW3ers8VcProdfp3vZ7nQo3cFu9Wqas/Ny82J6p+kolN0GrqnpW5PImEj2Xtn7zHVFxkSy5/Ieu54IDA0cyo6LO4hVsUxsN5HKeSvbre60YtOmTURERLBo0SI8PT2tDifN0Yk9nqCQIFzExW5PV1twZAHzjs4jd8bc/NnlT7vUqWnpSacynWjq15QLdy4wfOXwZ64v7qA9bnTJZ7Hvyj4iYiLsdvvZH3v/YOKeiQAMrT6UfpX62aXetOTgwYMcPXqUFStWkClTJqvDSZN0Yo8n6GIQ5XOXJ5PHs3+gwh6G0WteLwRhbf+16eaRgZpmb4t7L8bb3Zsftv3wzE3yvll8KZClANsvPntij3sMrD3O2A9eO8jLS1/GRVyoXaA237f4/pnrTGuuXLnCqlWrWLp0KXny5LE6nDRLZxobcc9rtlezWqM/GhERE8HHDT+mXO5ydqlT09IjLzcvpnacarcm+VoFahEU8uzPZg+6GES+TPme+Q6ae5H36DqnK9Gx0WTzysacbnPSXWe5hw8fsmDBAsaOHUvlypWtDidN04ndxokbJwh7GGaXxD5q8yj2XtlLhdwVGBkw0g7RaVr61qVsF5r4NeHCnQu8t/q9Z6qrlm8tzoSd4eq9q89UT1BIkPGs92e4DU0pxStLX+H4jeNEx0Yzo/MMu99qmxasWLGCNm3a0Lt3b6tDSfN0YrcR16z2rB3nTt44yQdrP8DD1YN1A9bZIzRN04BFPRfh5ebFN1u/4cytM09dT9w18bjv/NO4+eAmJ26eeOYTgT/2/cH0/UYHwffqvUfL4i2fqb606ODBg9y+fZtffvnF6lCcgk7sNoJCgsjskZnSOUs/dR1KKRr90YhYFcvkDpPT7SMVNS0leHt4M7H9RGJV7DM1yfvn88fNxe2ZOtDF3UHzLIn9xI0TDAkcgou4ULdgXT5tZN8hdNOCe/fusXr1ambNmoW3t7fV4TgFndhtBF0MorpvdVxdXJ+6jpeWvETI3RBaFGtBnwp97BidpmkAfSr0oXaB2py4eYIvN335VHV4u3tTKU+lZ0rsQSFBCEK1/NWeqnxkTCS95vUiIjqCLJ5ZmNV1Fm4ubk8dT1q1Zs0aBg4cSPXqKfeI7PTGYYldRFqKyDEROSkiIxJ431NEZpvvB4lIEZv33jOnHxORFjbTz4rIARHZKyI7nyW+B1EP2Hd13zMdfW86t4kJuyeQxTMLi3otepZwNE17jMA+gXi4ejBy3cinfrxrrQK12HFxBzGxMU9VPuhiEOVylyOz59MNczpy3Uh2Xd5FjIrh9w6/p8vr6qdOnSI0NJRPP01/LRUpySGJXURcgTFAK6As0EtEysabbSBwSylVHPgR+NosWxboCZQDWgJjzfriNFJKVVZKPd1hs2n35d1Ex0Y/dWKPiI6g7Z9tAVjSe0m669GqaY6UzSsbv7T6hRgVQ6uZrZ6qjloFanE/6j6HQg8lu6xS6pnuoFl7Zi3fbDEe7vJy1ZfpWLrjU9WTlsXExLBmzRrGjBmjm+DtzFFn7DWAk0qp00qpSGAWEH8Itg7AH+bfc4EmYnQ17QDMUkpFKKXOACfN+uzq0f2oTznQRPs/23Mn4g6D/AdRv1B9e4amaVoCBlcdTMU8Fdl/dT/jdo5Ldvm4TrJPc9vbyZsnufng5lMl9rCHYfRb0A8XcaF0ztLp8n51gF27dlG8eHHatUt/j6FNaY5K7L7ABZvXIea0BOdRSkUDtwGfJ5RVwEoR2SUigxNbuIgMFpGdIrIzNDQ0wXmCLgZROGth8mbKm/S1Mk3dO5WVp1fim9mXcW2Tv4PRNO3prOi7Aldx5fXlrxP2MCxZZYtlL4ZPBp+nus4edyJQwzf55xhvLHuDy3cvIyLM7jobb/f0d7YaERHBtm3bGD16dLp7Yp0jpPXOc/WUUv4YTfxDRKRBQjMppcYrpaopparlypUrwYp2XNzxVF/SK3evMGjJIFzEhbX91+oPqaY5UN5Mefkk4BMiYyJpNzN5Z34iQs0CNZ9qBLqgkCC83b2TPfDU/CPzmbrfGGjnm6bfUDFPxWQv2xns3LmTxo0bU6VKFatDcUqOSuwXgYI2rwuY0xKcR0TcgKzAjceVVUrF/b4GLOApm+hD74dyNuxsshO7UoomU5sQGRPJxw0/pmTOkk+zeE3TnsEHDT6gaLaibL6wmbmH5yarbC3fWhwOPZzss/2gi0FUy18tWb3Yr9y7wouLXsRFXAgoEsAbtd5I1jKdRUREBDt27OCzzz6zOhSn5ajEHgyUEBE/EfHA6AwXv9v4ImCA+XdXYK1SSpnTe5q95v2AEsAOEckoIpkBRCQj0Bw4+FTBXQoGoHr+5N1u8cGaDzh8/TDlc5fnwwYfPs2iNU2zg+V9lyMIA/4eQGR0ZJLLxfWp2Xkp6TfVRERHJPsOGqUUgxcPJuxhGBndMzK141RcJK03mD6dPXv2EBAQQJkyZawOxWk55JNlXjMfCqwAjgBzlFKHRORTEWlvzjYJ8BGRk8AwYIRZ9hAwBzgMLAeGKKVigDzAZhHZB+wAliqllj9NfMEXgxEE/3z+SS4TdDGIUVtG4e7izqq+q3QTvKZZqIRPCYbWGEp4VDjd53ZPcrm4g/m4wWaSYv/V/UTGRCarhW/mgZksPr4YhWJc23EUzFrwyYWcUExMDDt37uSDDz6wOhSn5rDREJRSgUBgvGkjbf5+CHRLpOwXwBfxpp0GKtkjtuBLwZTNVTbJ96PejbhLmxltUCjGtB5D3szJ73CnaZp9jW4xmtkHZ7Pw2EI2n99MvUL1nlgme4bslPQpmazEHjdvUhP7lXtXeDXwVQC6l+tOrwq9krwsZ3P06FH8/Pz0YDQpLH22BdlQShF8KZjqvkn7oCml6D2vNzce3KBB4Qa86P9iCkeoaVpSuLi48HfPvwHoOKsjsbGxSSpXw7cGQReDMK78PVnwpWByZ8xNwSxPPuuOa4K/G3GXXN65+K3Nb0lahrPat28fb7/9ttVhOL10n9jP3z7PtfvXknx9/fe9v7PkxBK83b35q9tfugle01KR2gVr07VsV248uMGQwCFJKlMjfw2u3LvCxbvx+/MmbMfFHVTPXz1J3/1ZB2c9aoKf0nEKOTLkSNIynNGNGzcIDQ2lU6dOVofi9NJ9Yk9Ox7njN47zytJXAJjUfhK5M+ZO0dg0TUu+GZ1mkMkjE+N2jeNI6JEnzh/XpJ6UgWruRtzl6PWjSWqGv3b/Gi8vfRmAFyq/QOsSrZ9Yxpnt37+f/v374+GhR+VMaTqxXwzG3cX9ifeTRkRH0HFWRyJjImldojU9y/d0UISapiWHh5sH0zsZj0FtM7PNE+evnLcy7i7uSbrOvuvyLhQqSScCQ5YO4W7EXfJnys+PLX9MUuzOKjY2lkOHDvH8889bHUq6oBP7pWAq562Mp5vnY+d7d/W7HLl+hMwemfm9w+8Oik7TtKfRoXQH6heqz5mwM3yx8YvHzuvp5knlvJXZcenJiT0u+T+pT87iY4uZe2QuCsX0ztPJ4pkl6cE7oZCQELJnz06lSnbp76w9QbpO7LEqlp2Xdj7x6DvwRCA/Bf0EwLi243QTvKalAUt6GQ9j+njDx1y7d+2x89bwrcHOSzuf+KS34EvB+GXzI6d3zkTnuf3wNgMXDQSMB7w08muU/OCdzNGjR+nVK/3eDeBo6TqxH7t+jLuRdx979B16P5T+C/ojCG1LtNVN8JqWRmTxysKPLX4kOjaa1jMff327hm8N7kXe4+j1o4+dLylDT7+98m1Cw0PJnyk/3zb/NtlxOxulFMePH6dr165Wh5JupOvE/qSOc0opBi0exM0HN8nskZnx7cbrXvCaloa8Wv1VyuQsw67Lu5i+b3qi88WNIhf3cJeEXLt/jfO3zz+2hW/juY1M2jMJgBldjE586d3Vq1fx8PCgfPnyVoeSbqTvxH4xmEwemSids3SC7/+x7w8WHluIQvFL61/IlzmfgyPUNO1ZLe+7HBdxYfCSwTyMfpjgPCV8SpDVM+tjO9AFXzRPBBJp4YuIjqDfgn4ADPYfTECRgGcL3EmcOnWKtm3b6pMiB0rXiX3HpR1UzVcVVxfXf713LuwcrwW+hou40LJYS/pV7GdBhJqmPatCWQvxdu23eRD9gC6zuyQ4j4u4UN23+mMT+46LO3ARl0SHnv5s42ecv32e3Blzp9tnrCckJCSE1q3T961+jpZuE3tkTCR7r+xNsFktVsXy3N/P8SD6ARncMugmeE1L475p9g35MuUj8GQg68+uT3CeGvlrsP/qfh5EPUjw/bihpxNqXj96/SijNo8CYGbnmboJ3hQdHc3Zs2cJCAiwOpR0Jd0m9gNXDxAZE5lgs9rY4LGsP7eeGBXDDy1+SLcPbNA0Z7Kol/FAyS5zuiQ43GzNAjWJUTHsvrz7X+8ppYyOc/n/3XEuVsXSe15vYlQMfSv0pUnRJvYPPo26dOkSfn5+ZM2a1epQ0pV0m9gT6zh34fYFRqwegau4ElA4gEH+g6wIT9M0O6uWvxo9yvXg5oObj0aEsxW3L0ioA93ZsLPceHAjwROB8bvGs+fKHrJ7ZefX1r/aP/A0LCQkhAYNGlgdRrqTbhP7zks78cngQ5FsRR5NU0oxNHAoD6If4O7qzsT2E3UTvKY5kemdp5PZIzMTd0/813Cz+TLno2CWgo8O+m0ldiIQej+UYSuGGXV3mk5WL31mais0NJS6detaHUa6k64Te7X81f6RuOcfmc+i44uIVbF81eQriuUoZmGEmqbZm5uL26PhZhO6t726b/VHvd9tBV8MxsPVgwp5Kvxj+guLXuBB9APal2pP65K6g1h8ly9fxt8/4c6GWspJl4k9PCqcg9cOUi1/tUfTwh6G8Wrgq7iKKzV9a/JajdcsjFDTtJTSvnR76heqz9mws/8abrZ6/uqcunWKmw9u/mP6zss7qZy3Mh6u//8Ak9WnV7PkuPGkRz3M9L9FRkZy69YtSpUqZXUo6U66TOz7ruwjRsX8o1ltxOoRhN4PRUSY3GFygrfAaZrmHBb3WpzgcLNxo8rZnrXHqlh2XdpFtXz/fyIQER1B73m9ARjfbny6fhxrYq5du0bRokVxddX7UkdLl4l956WdAI/O2Hdd2sX4XeNRKP7b8L+UzVXWyvA0TUthWb2y8kPzH/413GzVfFUB/nGdPaGhp99d/S6h4aHUKVCH3uV7Oy7wNCQ0NJQyZcpYHUa6lC4Te/ClYPJmykv+zPmJVbG8svQVRITyucrzbt13rQ5P0zQHGFJjyKPhZqfumwoYCb90ztL/GKgm7kQgroXv+I3j/Bz0M+4u7sztPld3sE1EeHg4pUsnPKqnlrLSZWK37Tg3Y/8Mgi8Fo5Tij05/4O7qbnV4mqY5yLK+y3ARF15e8jLhkeGAkcDj9glgnAhkdM9I6ZylUUrRaXYnFIqvmn6lh5l+gmLFdAdkK6S7xB6rYjl6/SjV81fnbsRd3lzxJgDv1Hkn0aEiNU1zToWzFn403GzXv4ynj1XPX50r965wK+YWYCR2/3z+uLq4Mn7XeA6HHqZEjhIMqzXMytDThEKFClkdQrqU7hL7/aj7KBTV8lfjv+v/y80HNymYpSAfB3xsdWiaplkgbrjZZSeXseb0mkcd6E5HniZaRT8aevrOwzu8ueJNBGFJ7yW6CT4J8ufPb3UI6VK6S+xxzW3ZvbLzU9BPgDFoRQb3DFaGpWmaheKGm+32Vzcq5K6Am4sbZyLOcCnqEg+jH1Ldtzq95vXiYfRDXqvxGiV9SloccdqQN29eq0NIl9JdYr8fdZ9CWQsxYvUIYlUsAyoNoEFhPeShpqVn1fJXo1f5Xtx6eIvXl79OpTyVOBt5ljMRZwCIiY0h8GQgubxz8UOLHyyONvWLiooCIHv27BZHkj6lu8QeHhVOoSyF2Hh+I1k8s/Bzq5+tDknTtFRgaqepZPHMwuQ9kymWvRhnIs5wOvI02b2y8+byNwGY132eHuMiCW7eNAb40ZcrrJHuEntEdAT7ru4DYEqHKWTxzGJxRJqmpQZuLm7M6DQDhWLNmTU8UA/YFb6LLJ5ZuP7gOu1KtqN+4fpWh5kmhIWFWR1CuuawxC4iLUXkmIicFJERCbzvKSKzzfeDRKSIzXvvmdOPiUiLpNaZmLuRd6lbsC6dynR65vXSNM15tC3VloDCAdx4cAOA+7H3OXf7HBncMjC762yLo0s77ty5Y3UI6ZpDEruIuAJjgFZAWaCXiMQf3m0gcEspVRz4EfjaLFsW6AmUA1oCY0XENYl1JshVXJnfY/6zr5imaU5nYc+FuLv8czyL39r8pjvYJsO9e/esDiFdc9QZew3gpFLqtFIqEpgFdIg3TwfgD/PvuUATMS7QdABmKaUilFJngJNmfUmpM0Fts7Qld8bcREVFERAQwPTp0wFjpKSAgABmzzaOzG/fvk1AQADz5xsHAdevXycgIIDFixcDcOXKFQICAli+fDkAFy5cICAggNWrVwNw+vRpAgIC2LBhAwDHjh0jICCArVu3AnDw4EECAgIIDjaGr9y7dy8BAQHs3bsXgODgYAICAjh48CAAW7duJSAggGPHjgGwYcMGAgICOH36NACrV68mICCACxcuALB8+XICAgK4cuUKAIsXLyYgIIDr168DMH/+fAICArh9+zYAs2fPJiAggPBw486B6dOnExAQ8KgjzJQpUwgICHi0HSdMmEDTpk0fvR47diytWrV69Pqnn36iffv2j15/9913dOnS5dHrUaNG0bNnz0evP/vsM/r27fvo9ciRI3n++ecfvX7vvfcYPHjwo9fDhw9nyJAhj16/+eabvPnmm49eDxkyhOHDhz96PXjwYN57771Hr59//nlGjhz56HXfvn357LPPHr3u2bMno0aNevS6S5cufPfdd49et2/fnp9++unR61atWjF27NhHr5s2bcqECRMevQ4ICGDKlCkAdv/s3bhxg1GjRunPnulZPntZvLLQLKoZGOPTUCZnGY7OPqo/ezafvSeJ+z9q1pC40ZVSdCEiXYGWSqkXzdf9gJpKqaE28xw05wkxX58CagIfA9uVUtPN6ZOAZWaxx9ZpU/dgIO5bWR44aPeV1JIrJ3Dd6iCcjN6m9qe3acJKKaUy204QkVDgnPmyquNDchrngVDz78JKqVzJrcDNvvGkTkqp8cB4ABHZqZSq9oQiWgrT/wf709vU/vQ2TZiI7Iw/7WkSkJYyHNUUfxEoaPO6gDktwXlExA3ICtx4TNmk1KlpmqZp6YqjEnswUEJE/ETEA6Mz3KJ48ywCBph/dwXWKuM6wSKgp9lr3g8oAexIYp2apmmalq44pCleKRUtIkOBFYArMFkpdUhEPgV2KqUWAZOAaSJyEriJkagx55sDHAaigSFKqRiAhOpMQjjj7bx62tPR/wf709vU/vQ2TZjeLqmYQzrPaZqmaZrmGOlu5DlN0zRNc2Y6sWuapmmaE9GJXXMYEbkX7/VzIvKrVfE4CxGJEZG9InJQRP4SEW+rY9Kcj4goEfne5vVwEfnYwpC0ROjErmlp3wOlVGWlVHkgEnjZ6oA0pxQBdBaRnFYHAiAiU8yDDSUiUSJyTUTWicgQEXGPN29pEflTRK6KSISInBGR70Uke7z5/ERkuoiEmPNdEpGlIlLFsWv3bNJNYrc5q4n70Ts/zRltAopbHURap/cXCYrG6A3/ltWB2FgN5AOKAM2BxcAnwCYRyQggIjUwbo/ODHTEuGX6NYznjGwVkWzmfO7AKiAX0B0oCXTBuL06h4PWxy7SxchzpgdKqcpWB5HOZRCRvTavc6DHHrAbc2CnVsByq2NxAnp/kbAxwH4R+cbqQEwRSqm4wesvAntFZCWwG/iPealgMnAcaK+UijXnPS8iuzGePfIFMATjQWPFMIYqP2nOdw7Y5pA1saN0c8aupQpxTcaVzZ3myCcV0JIk7oBpJ8Y405OsDUdzVkqpO8BU4HWrY0mMUuogxsFtF6AyRsL+3iapx813CZiB8WRQwRifPRboYh4kp1k6sWta2md7wPSa+bRDTUspozEes53R4jge5zBQFKM5HeDIY+bLDuRSSl3EOGAZCYSJyAYR+UxEyqV4tHamE7umaZqWZEqpm8AcjOSeWgmPHrybdEqpMUBeoDewGeNR4HvNp4emGTqxa5qmacn1PcYjbVOrssBpjGvrca8Tm+8W//+YVJRSd5VSi5RSHwCVgHXAZykYq93pxK45jFIqU7zXU5RSQ62Kx1nE366alhJsP2dKqatKKW+l1McWhpQgESkPtATmAnsxmuHfFhGXePPlB/oAf6pExlY3px8F0tR3TCd2TdM0La3yFJG8IpJfRCqJyDBgPbAL+M5MzC9gXGtfKCK1RaSgiLTBuFXuHPAhgIhUFpGFItJVRMqKSHERGWiWX2DFyj0t/RAYTdM0Lc0RkSn8/6O+Y4Aw4CDGmfp4206kIlIWo1NcYyAbcAmYD3ymlLplzpMT+ABognFfvAvGXSZzgFFKqYcpvEp2oxO7pmmapjkR3RSvaZqmaU5EJ3ZN0zRNcyI6sWuapmmaE9GJXdM0TdOciE7smqZpmuZEdGLXNE3TNCeiE7umaZqmORGd2DVN0zTNiejErmmapmlO5P8AH/kRpKp9jhUAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 504x288 with 2 Axes>"
       ]
@@ -232,78 +333,31 @@
     }
    ],
    "source": [
-    "from ase.phonons import Phonons\n",
-    "from pymatgen.io.ase import AseAtomsAdaptor\n",
-    "\n",
-    "from m3gnet.models import M3GNet, M3GNetCalculator, Potential\n",
-    "\n",
-    "relaxed = mpr.get_structure_by_material_id(\"mp-129\")\n",
-    "\n",
-    "# Setup crystal and EMT calculator\n",
-    "atoms = AseAtomsAdaptor().get_atoms(relaxed)\n",
-    "\n",
-    "potential = Potential(M3GNet.load())\n",
-    "\n",
-    "calculator = M3GNetCalculator(potential=potential, stress_weight=0.01)\n",
-    "\n",
-    "# Phonon calculator\n",
-    "N = 7\n",
-    "ph = Phonons(atoms, calculator, supercell=(N, N, N), delta=0.05)\n",
-    "ph.run()\n",
-    "\n",
-    "# Read forces and assemble the dynamical matrix\n",
-    "ph.read(acoustic=True)\n",
-    "ph.clean()\n",
-    "\n",
-    "path = atoms.cell.bandpath(\"GHPGN\", npoints=100)\n",
-    "bs = ph.get_band_structure(path)\n",
-    "\n",
-    "dos = ph.get_dos(kpts=(20, 20, 20)).sample_grid(npts=100, width=1e-3)\n",
-    "\n",
     "# Plot the band structure and DOS:\n",
-    "import matplotlib.pyplot as plt  # noqa\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.rc(\"figure\", dpi=150)\n",
     "\n",
     "fig = plt.figure(1, figsize=(7, 4))\n",
-    "ax = fig.add_axes([0.12, 0.07, 0.67, 0.85])\n",
+    "bs_ax = fig.add_axes([0.12, 0.07, 0.67, 0.85])\n",
     "\n",
     "emax = 0.035\n",
-    "bs.plot(ax=ax, emin=0.0, emax=emax)\n",
+    "bs.plot(ax=bs_ax, emin=0.0, emax=emax)\n",
     "\n",
-    "dosax = fig.add_axes([0.8, 0.07, 0.17, 0.85])\n",
-    "dosax.fill_between(dos.get_weights(), dos.get_energies(), y2=0, color=\"grey\", edgecolor=\"k\", lw=1)\n",
+    "dos_ax = fig.add_axes([0.8, 0.07, 0.17, 0.85])\n",
+    "dos_ax.fill_between(dos.get_weights(), dos.get_energies(), y2=0, color=\"grey\", edgecolor=\"black\", lw=1)\n",
     "\n",
-    "dosax.set_ylim(0, emax)\n",
-    "dosax.set_yticks([])\n",
-    "dosax.set_xticks([])\n",
-    "dosax.set_xlabel(\"DOS\", fontsize=18)"
+    "dos_ax.set_ylim(0, emax)\n",
+    "dos_ax.set_yticks([])\n",
+    "dos_ax.set_xticks([])\n",
+    "dos_ax.set_xlabel(\"DOS\", fontsize=14)\n",
+    "\n",
+    "fig.suptitle(\n",
+    "    f\"Phonon band structure and DOS of LiFePO4 {mp_129.formula} ({mp_id}) with {supercell} supercell\",\n",
+    "    fontsize=12,\n",
+    "    y=1.02,\n",
+    ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "5880ae6f",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "343"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ca07282d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Adds measurement of reduction in mean diff of frac. coords. pre vs post m3gnet relaxation of strained LFP structure in `examples/Relaxation of LiFePO4.ipynb`. Plus new `nbstripout` commit hook to remove unnecessary cell metadata like execution count at commit time.

![Screen Shot 2022-08-16 at 15 16 23](https://user-images.githubusercontent.com/30958850/184995537-bdcb93cd-8543-4c37-8897-deb898a7b11b.png)
