### PR TITLE
make energy from M3GNetCalculator a float

### DIFF
--- a/m3gnet/models/_dynamics.py
+++ b/m3gnet/models/_dynamics.py
@@ -85,8 +85,8 @@ class M3GNetCalculator(Calculator):
         graph_list = graph.as_tf().as_list()
         results = self.potential.get_efs_tensor(graph_list, include_stresses=self.compute_stress)
         self.results.update(
-            energy=results[0].numpy().ravel(),
-            free_energy=results[0].numpy().ravel(),
+            energy=results[0].numpy().ravel()[0],
+            free_energy=results[0].numpy().ravel()[0],
             forces=results[1].numpy(),
         )
         if self.compute_stress:


### PR DESCRIPTION
As discussed in #32 I converted the energies returned by the M3GNetCalculator to a single float instead of an array with one element.
The examples with MD and Relaxer return exactly the same results as before, both for values and trajectories.
