### PR TITLE
Let stress have the same sign as stress in VASP

### DIFF
--- a/m3gnet/models/_base.py
+++ b/m3gnet/models/_base.py
@@ -199,7 +199,7 @@ class BasePotential(tf.keras.Model, ABC):
         results: tuple = (energies, forces)
         # eV/A^3 to GPa
         if include_stresses:
-            stresses = 1 / volume[:, None, None] * derivatives["stresses"] * 160.21766208
+            stresses = -1 / volume[:, None, None] * derivatives["stresses"] * 160.21766208
             stresses = tf.cast(tf.convert_to_tensor(stresses), DataType.tf_float)
             results += (stresses,)
         return results

--- a/m3gnet/trainers/_potential.py
+++ b/m3gnet/trainers/_potential.py
@@ -54,14 +54,14 @@ class PotentialTrainer:
         """
         Args:
             graphs_or_structures (list): a list of MaterialGraph or structures
-            energies (list): list of train energies
-            forces (list): list of train forces
-            stresses (list): list of train stresses
+            energies (list): list of train energies with unit of eV
+            forces (list): list of train forces with unit of eV/Å
+            stresses (list): list of train stresses with unit of GPa
             validation_graphs_or_structures (list): optional list of validation
                 graphs or structures
-            val_energies (list): list of val energies
-            val_forces (list): list of val forces
-            val_stresses (list): list of val stresses
+            val_energies (list): list of val energies with unit of eV
+            val_forces (list): list of val forces with unit of eV/Å
+            val_stresses (list): list of val stresses with unit of GPa
             loss (tf.keras.losses.Loss): loss object
             force_loss_ratio (float): the ratio of forces in loss
             stress_loss_ratio (float): the ratio of stresses in loss


### PR DESCRIPTION
From my tests, the m3gnet is now predicting stress in an opposite sign with respect to that in VASP. 

My test shows that R2 score of stresses predicted by M3GNet for a test data set (~9000 structures) from the Materials Project (MP) relaxation trajectories is ~0.8 if the MP stresses are multipled by -0.1; Otherwise, if the MP stresses are multiplied by 0.1 (KBar in VASP to GPa in M3GNet), R2 score is negative.

As an example, I have attached the DFT data from MP ([mp_10064-1-1.json.zip](https://github.com/materialsvirtuallab/m3gnet/files/10663823/mp_10064-1-1.json.zip)) for structure id of mp-10064-1-1, which can be found in the training data of M3GNet on figshare. The below snapshots show that while energies and forces predicted by M3GNet is matching well with MP DFT results, the predicted stress is having different sign compared to that of DFT, which might be mistreated as an absolute error of 20 GPa.
<img width="870" alt="Screen Shot 2023-02-06 at 10 06 28 PM" src="https://user-images.githubusercontent.com/54908836/216992377-6e056cb2-1aef-4c36-9040-3793cbf6f661.png">


There seems not a good reason to keep the stress sign as opposite to VASP, so I'm changing it in this PR. Some minor documentation about units for training energies, forces and stresses are also added in.